### PR TITLE
Remove dependency to older Jackson-databind

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use module on Maven-based projects, use following dependency:
 <dependency>
   <groupId>com.hubspot.jackson</groupId>
   <artifactId>jackson-datatype-protobuf</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4</version>
 </dependency>
 ```
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.PropertyNamingStrategyBase;
-//import com.fasterxml.jackson.databind.deser.impl.NullProvider;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.type.SimpleType;
 import com.google.common.base.Function;
@@ -208,7 +207,6 @@ public class ProtobufDeserializer<T extends Message> extends StdDeserializer<Mes
 
         if (value == null) {
           getNullValue(SimpleType.construct(Integer.TYPE), 0, context);
-//          new NullProvider(SimpleType.construct(Integer.TYPE), 0).nullValue(context);
         }
         break;
       case LONG:
@@ -216,7 +214,6 @@ public class ProtobufDeserializer<T extends Message> extends StdDeserializer<Mes
 
         if (value == null) {
           getNullValue(SimpleType.construct(Long.TYPE), 0L, context);
-//          new NullProvider(SimpleType.construct(Long.TYPE), 0L).nullValue(context);
         }
         break;
       case FLOAT:
@@ -224,7 +221,6 @@ public class ProtobufDeserializer<T extends Message> extends StdDeserializer<Mes
 
         if (value == null) {
           getNullValue(SimpleType.construct(Float.TYPE), 0.0f, context);
-//          new NullProvider(SimpleType.construct(Float.TYPE), 0.0f).nullValue(context);
         }
         break;
       case DOUBLE:
@@ -232,7 +228,6 @@ public class ProtobufDeserializer<T extends Message> extends StdDeserializer<Mes
 
         if (value == null) {
           getNullValue(SimpleType.construct(Double.TYPE), 0.0d, context);
-//          new NullProvider(SimpleType.construct(Double.TYPE), 0.0d).nullValue(context);
         }
         break;
       case BOOLEAN:
@@ -240,7 +235,6 @@ public class ProtobufDeserializer<T extends Message> extends StdDeserializer<Mes
 
         if (value == null) {
           getNullValue(SimpleType.construct(Boolean.TYPE), false, context);
-//          new NullProvider(SimpleType.construct(Boolean.TYPE), false).nullValue(context);
         }
         break;
       case STRING:

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
@@ -1,6 +1,7 @@
 package com.hubspot.jackson.datatype.protobuf;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -8,7 +9,7 @@ import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.PropertyNamingStrategyBase;
-import com.fasterxml.jackson.databind.deser.impl.NullProvider;
+//import com.fasterxml.jackson.databind.deser.impl.NullProvider;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.type.SimpleType;
 import com.google.common.base.Function;
@@ -180,6 +181,15 @@ public class ProtobufDeserializer<T extends Message> extends StdDeserializer<Mes
     }
   }
 
+  private Object getNullValue(JavaType type, Object nullValue, DeserializationContext context) throws JsonProcessingException {
+    if (type.isPrimitive() && context.isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)) {
+      throw context.mappingException("Can not map JSON null into type %s"
+          + " (set DeserializationConfig.DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES to 'false' to allow) -- "
+          + type.getRawClass().getName());
+    }
+    return nullValue;
+  }
+
   private Object readValue(Message.Builder builder, FieldDescriptor field, Message defaultInstance, JsonParser parser,
                            DeserializationContext context) throws IOException {
     final Object value;
@@ -197,35 +207,40 @@ public class ProtobufDeserializer<T extends Message> extends StdDeserializer<Mes
         value = _parseInteger(parser, context);
 
         if (value == null) {
-          new NullProvider(SimpleType.construct(Integer.TYPE), 0).nullValue(context);
+          getNullValue(SimpleType.construct(Integer.TYPE), 0, context);
+//          new NullProvider(SimpleType.construct(Integer.TYPE), 0).nullValue(context);
         }
         break;
       case LONG:
         value = _parseLong(parser, context);
 
         if (value == null) {
-          new NullProvider(SimpleType.construct(Long.TYPE), 0L).nullValue(context);
+          getNullValue(SimpleType.construct(Long.TYPE), 0L, context);
+//          new NullProvider(SimpleType.construct(Long.TYPE), 0L).nullValue(context);
         }
         break;
       case FLOAT:
         value = _parseFloat(parser, context);
 
         if (value == null) {
-          new NullProvider(SimpleType.construct(Float.TYPE), 0.0f).nullValue(context);
+          getNullValue(SimpleType.construct(Float.TYPE), 0.0f, context);
+//          new NullProvider(SimpleType.construct(Float.TYPE), 0.0f).nullValue(context);
         }
         break;
       case DOUBLE:
         value = _parseDouble(parser, context);
 
         if (value == null) {
-          new NullProvider(SimpleType.construct(Double.TYPE), 0.0d).nullValue(context);
+          getNullValue(SimpleType.construct(Double.TYPE), 0.0d, context);
+//          new NullProvider(SimpleType.construct(Double.TYPE), 0.0d).nullValue(context);
         }
         break;
       case BOOLEAN:
         value = _parseBoolean(parser, context);
 
         if (value == null) {
-          new NullProvider(SimpleType.construct(Boolean.TYPE), false).nullValue(context);
+          getNullValue(SimpleType.construct(Boolean.TYPE), false, context);
+//          new NullProvider(SimpleType.construct(Boolean.TYPE), false).nullValue(context);
         }
         break;
       case STRING:


### PR DESCRIPTION
Removing the dependency to NullProvider, a (almost internal) class that has been deprecated since 2.6, will allow the lib to be compatible with newer Jackson, e.g. 2.8 & 2.9.
Indeed NullProvider class was completely removed from 2.8.
See https://github.com/HubSpot/jackson-datatype-protobuf/issues/15
