### PR TITLE
replace class usages that are unavailable on older Android devices

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ExtensionRegistryWrapper.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ExtensionRegistryWrapper.java
@@ -57,7 +57,7 @@ public class ExtensionRegistryWrapper {
       field.setAccessible(true);
       Map<String, ExtensionInfo> extensionInfoMap = (Map<String, ExtensionInfo>) field.get(extensionRegistry);
       return extensionInfoMap.values();
-    } catch (ReflectiveOperationException e) {
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializerFactory.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializerFactory.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.deser.Deserializers;
 import com.google.protobuf.Message;
 
-import java.util.Objects;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -80,7 +82,10 @@ public class ProtobufDeserializerFactory extends Deserializers.Base {
 
     @Override
     public int hashCode() {
-      return Objects.hash(messageType, build);
+      List<Object> toHashCode = new ArrayList<>();
+      toHashCode.add(messageType);
+      toHashCode.add(build);
+      return Arrays.hashCode(toHashCode.toArray());
     }
   }
 }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializerFactory.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializerFactory.java
@@ -73,7 +73,9 @@ public class ProtobufDeserializerFactory extends Deserializers.Base {
       }
 
       CacheKey cacheKey = (CacheKey) o;
-      return Objects.equals(build, cacheKey.build) && Objects.equals(messageType, cacheKey.messageType);
+      boolean buildEquals = build == cacheKey.build;
+      boolean messageTypeEquals = messageType == cacheKey.messageType || messageType != null && messageType.equals(cacheKey.messageType);
+      return buildEquals && messageTypeEquals;
     }
 
     @Override


### PR DESCRIPTION
This PR replaces an some class that are unavailable on older Android devices. This enables Android projects supporting older Android devices to use this library.

`java.util.Objects` was only added to Android in API 19 (see: https://developer.android.com/reference/java/util/Objects.html).
Same for the ReflectionException.

Projects supporting lower Android API levels but using this library will see `NoClassDefFoundError`s on devices running an older Android version.