### PR TITLE
Add a generic enum-as-number serdes

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ProtocolMessageEnum;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public final class ProtobufEnumAsNumber {
 
@@ -35,10 +36,11 @@ public final class ProtobufEnumAsNumber {
     }
   }
 
+  @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
   public static class Deserializer extends StdDeserializer<ProtocolMessageEnum> implements ContextualDeserializer {
 
-    private final Class<?> enumClass;
-    private final Method forNumberMethod;
+    private final transient Class<?> enumClass;
+    private final transient Method forNumberMethod;
 
     protected Deserializer() {
       this(null, null);

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
@@ -36,7 +36,7 @@ public final class ProtobufEnumAsNumber {
     }
   }
 
-  @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED")
+  @SuppressFBWarnings({"SE_TRANSIENT_FIELD_NOT_RESTORED", "SE_NO_SERIALVERSIONID"})
   public static class Deserializer extends StdDeserializer<ProtocolMessageEnum> implements ContextualDeserializer {
 
     private final transient Class<?> enumClass;

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ProtocolMessageEnum;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public final class ProtobufEnumAsNumber {

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumber.java
@@ -1,0 +1,79 @@
+package com.hubspot.jackson.datatype.protobuf;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.google.common.base.Preconditions;
+import com.google.protobuf.ProtocolMessageEnum;
+
+public final class ProtobufEnumAsNumber {
+
+  private ProtobufEnumAsNumber() {}
+
+  public static class Serializer extends StdSerializer<ProtocolMessageEnum> {
+
+    protected Serializer() {
+      super(ProtocolMessageEnum.class);
+    }
+
+    @Override
+    public void serialize(ProtocolMessageEnum protocolMessageEnum, JsonGenerator jsonGenerator, SerializerProvider provider) throws IOException {
+      jsonGenerator.writeNumber(protocolMessageEnum.getNumber());
+    }
+  }
+
+  public static class Deserializer extends StdDeserializer<ProtocolMessageEnum> implements ContextualDeserializer {
+
+    private final JavaType javaType;
+
+    protected Deserializer() {
+      this(null);
+    }
+
+    protected Deserializer(JavaType javaType) {
+      super(ProtocolMessageEnum.class);
+      this.javaType = javaType;
+    }
+
+    @Override
+    public JsonDeserializer<?> createContextual(DeserializationContext context, BeanProperty beanProperty) {
+      // beanProperty is null when the type to deserialize is the top-level type or a generic type, not a type of a bean property
+      JavaType javaType = context.getContextualType();
+
+      if (javaType == null) {
+        javaType = beanProperty.getMember().getType();
+      }
+
+      return new Deserializer(javaType);
+    }
+
+    @Override
+    public ProtocolMessageEnum deserialize(JsonParser jsonParser, DeserializationContext context) throws IOException {
+      int intValue = jsonParser.getIntValue();
+      Class<?> enumClass = Preconditions.checkNotNull(javaType, "javaType").getRawClass();
+      try {
+        return (ProtocolMessageEnum) enumClass.getMethod("forNumber", int.class).invoke(null, intValue);
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        context.reportWrongTokenException(ProtocolMessageEnum.class, JsonToken.VALUE_NUMBER_INT, wrongTokenMessage(context));
+        // the previous method should have thrown
+        throw new AssertionError();
+      }
+    }
+  }
+
+  // TODO share this?
+  private static String wrongTokenMessage(DeserializationContext context) {
+    return "Can not deserialize instance of com.google.protobuf.ProtocolMessageEnum out of " + context.getParser().currentToken() + " token";
+  }
+}

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumberTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/ProtobufEnumAsNumberTest.java
@@ -1,0 +1,56 @@
+package com.hubspot.jackson.datatype.protobuf;
+
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.Enum;
+
+public class ProtobufEnumAsNumberTest {
+
+  @Test
+  public void itSerializesToEnumNumber() {
+    ObjectMapper mapper = camelCase();
+
+    for (Enum anEnum : Enum.values()) {
+      ObjectWithProtobufEnumField input = new ObjectWithProtobufEnumField();
+      input.anEnum = anEnum;
+
+      JsonNode node = mapper.valueToTree(input);
+
+      assertThat(node.has("anEnum")).isTrue();
+      assertThat(node.get("anEnum").isInt()).isTrue();
+      assertThat(node.get("anEnum").intValue()).isEqualTo(anEnum.getNumber());
+    }
+  }
+
+  @Test
+  public void itDeserializesFromEnumNumber() throws JsonProcessingException {
+    ObjectMapper mapper = camelCase();
+
+    for (Enum anEnum : Enum.values()) {
+      ObjectWithProtobufEnumField input = new ObjectWithProtobufEnumField();
+      input.anEnum = anEnum;
+
+      JsonNode node = mapper.valueToTree(input);
+
+      ObjectWithProtobufEnumField output = mapper.treeToValue(node, ObjectWithProtobufEnumField.class);
+      assertThat(output).isNotSameAs(input);
+      assertThat(output.anEnum).isEqualTo(input.anEnum);
+    }
+  }
+
+  private static class ObjectWithProtobufEnumField {
+
+    @JsonSerialize(using = ProtobufEnumAsNumber.Serializer.class)
+    @JsonDeserialize(using = ProtobufEnumAsNumber.Deserializer.class)
+    private TestProtobuf.Enum anEnum;
+  }
+}


### PR DESCRIPTION
This is particularly useful when you want to serialize a specific field on a
specific type in this manner, without modifying the root object mapper config.

@jhaber 