### PR TITLE
Support custom json_name annotation

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
@@ -109,7 +109,8 @@ public class MessageDeserializer<T extends Message, V extends Builder> extends P
 
     Map<String, FieldDescriptor> fieldLookup = new HashMap<>();
     for (FieldDescriptor field : descriptor.getFields()) {
-      fieldLookup.put(namingStrategy.translate(field.getName()), field);
+      String fieldName = field.toProto().hasJsonName() ? field.getJsonName() : field.getName();
+      fieldLookup.put(namingStrategy.translate(fieldName), field);
     }
 
     if (config.acceptLiteralFieldnames()) {

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
@@ -65,18 +65,19 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
     }
 
     for (FieldDescriptor field : fields) {
+      String fieldName = field.toProto().hasJsonName() ? field.getJsonName() : field.getName();
       if (field.isRepeated()) {
         List<?> valueList = (List<?>) message.getField(field);
 
         if (!valueList.isEmpty() || writeEmptyCollections) {
           if (field.isMapField()) {
-            generator.writeFieldName(namingStrategy.translate(field.getName()));
+            generator.writeFieldName(namingStrategy.translate(fieldName));
             writeMap(field, valueList, generator, serializerProvider);
           } else if (valueList.size() == 1 && writeSingleElementArraysUnwrapped(serializerProvider)) {
-            generator.writeFieldName(namingStrategy.translate(field.getName()));
+            generator.writeFieldName(namingStrategy.translate(fieldName));
             writeValue(field, valueList.get(0), generator, serializerProvider);
           } else {
-            generator.writeArrayFieldStart(namingStrategy.translate(field.getName()));
+            generator.writeArrayFieldStart(namingStrategy.translate(fieldName));
             for (Object subValue : valueList) {
               writeValue(field, subValue, generator, serializerProvider);
             }
@@ -84,10 +85,10 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
           }
         }
       } else if (message.hasField(field) || (writeDefaultValues && !supportsFieldPresence(field) && field.getContainingOneof() == null)) {
-        generator.writeFieldName(namingStrategy.translate(field.getName()));
+        generator.writeFieldName(namingStrategy.translate(fieldName));
         writeValue(field, message.getField(field), generator, serializerProvider);
       } else if (include == Include.ALWAYS && field.getContainingOneof() == null) {
-        generator.writeFieldName(namingStrategy.translate(field.getName()));
+        generator.writeFieldName(namingStrategy.translate(fieldName));
         generator.writeNull();
       }
     }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingTest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.hubspot.jackson.datatype.protobuf.util.ProtobufCreator;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.PropertyNamingCamelCased;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.PropertyNamingCustomName;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.PropertyNamingSnakeCased;
 
 public class PropertyNamingTest {
@@ -151,5 +152,15 @@ public class PropertyNamingTest {
     PropertyNamingSnakeCased message = mapper.readValue(json, PropertyNamingSnakeCased.class);
 
     assertThat(message.getStringAttribute()).isEqualTo("test");
+  }
+
+  @Test
+  public void itRespectsCustomJsonPropertyNames() throws IOException {
+    ObjectMapper mapper = new ObjectMapper().registerModules(new ProtobufModule());
+    String json = "{\"custom-name\":\"test\"}";
+    PropertyNamingCustomName message = mapper.readValue(json, PropertyNamingCustomName.class);
+
+    assertThat(message.getCustomName()).isEqualTo("test");
+    assertThat(mapper.writeValueAsString(message)).isEqualTo(json);
   }
 }

--- a/src/test/proto/test.proto
+++ b/src/test/proto/test.proto
@@ -46,6 +46,10 @@ message RepeatedFields {
   extensions 18 to 34;
 }
 
+message PropertyNamingCustomName {
+    optional string custom_name = 1 [json_name = "custom-name"];
+}
+
 message PropertyNamingSnakeCased {
   optional string string_attribute = 1;
 }


### PR DESCRIPTION
I'm working with an existing API that sometimes dasherizes certain fields. To support this, I need to use the `json_name` field label annotation to make my objects serialize / deserialize correctly into underscored protobuf field names.

This PR adds serializer / deserializer support to use the `json_name` label annotation. (See: https://developers.google.com/protocol-buffers/docs/proto3#json)

Tests: Unit.

Thanks!