### PR TITLE
Add config option to fail on unknown enum values

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
@@ -5,10 +5,13 @@ import com.google.protobuf.ExtensionRegistry;
 public class ProtobufJacksonConfig {
   private final ExtensionRegistryWrapper extensionRegistry;
   private final boolean acceptLiteralFieldnames;
+  private final UnknownEnumSerializationStrategy unknownEnumSerializationStrategy;
 
-  private ProtobufJacksonConfig(ExtensionRegistryWrapper extensionRegistry, boolean acceptLiteralFieldnames) {
+  private ProtobufJacksonConfig(ExtensionRegistryWrapper extensionRegistry, boolean acceptLiteralFieldnames,
+      UnknownEnumSerializationStrategy unknownEnumSerializationStrategy) {
     this.extensionRegistry = extensionRegistry;
     this.acceptLiteralFieldnames = acceptLiteralFieldnames;
+    this.unknownEnumSerializationStrategy = unknownEnumSerializationStrategy;
   }
 
   public static Builder builder() {
@@ -23,9 +26,14 @@ public class ProtobufJacksonConfig {
     return acceptLiteralFieldnames;
   }
 
+  public UnknownEnumSerializationStrategy unknownEnumSerializationStrategy() {
+    return unknownEnumSerializationStrategy;
+  }
+
   public static class Builder {
     private ExtensionRegistryWrapper extensionRegistry = ExtensionRegistryWrapper.empty();
     private boolean acceptLiteralFieldnames = false;
+    private UnknownEnumSerializationStrategy unknownEnumSerializationStrategy = UnknownEnumSerializationStrategy.SERIALIZE;
 
     private Builder() {}
 
@@ -43,8 +51,13 @@ public class ProtobufJacksonConfig {
       return this;
     }
 
+    public Builder unknownEnumSerializationStrategy(UnknownEnumSerializationStrategy unknownEnumSerializationStrategy) {
+      this.unknownEnumSerializationStrategy = unknownEnumSerializationStrategy;
+      return this;
+    }
+
     public ProtobufJacksonConfig build() {
-      return new ProtobufJacksonConfig(extensionRegistry, acceptLiteralFieldnames);
+      return new ProtobufJacksonConfig(extensionRegistry, acceptLiteralFieldnames, unknownEnumSerializationStrategy);
     }
   }
 }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufModule.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufModule.java
@@ -82,22 +82,22 @@ public class ProtobufModule extends Module {
   public void setupModule(SetupContext context) {
     SimpleSerializers serializers = new SimpleSerializers();
     serializers.addSerializer(new MessageSerializer(config));
-    serializers.addSerializer(new DurationSerializer());
-    serializers.addSerializer(new FieldMaskSerializer());
-    serializers.addSerializer(new ListValueSerializer());
+    serializers.addSerializer(new DurationSerializer(config));
+    serializers.addSerializer(new FieldMaskSerializer(config));
+    serializers.addSerializer(new ListValueSerializer(config));
     serializers.addSerializer(new NullValueSerializer());
-    serializers.addSerializer(new StructSerializer());
-    serializers.addSerializer(new TimestampSerializer());
-    serializers.addSerializer(new ValueSerializer());
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(DoubleValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(FloatValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int64Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt64Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int32Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt32Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BoolValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(StringValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BytesValue.class));
+    serializers.addSerializer(new StructSerializer(config));
+    serializers.addSerializer(new TimestampSerializer(config));
+    serializers.addSerializer(new ValueSerializer(config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(DoubleValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(FloatValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int64Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt64Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int32Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt32Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BoolValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(StringValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BytesValue.class, config));
 
     context.addSerializers(serializers);
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/UnknownEnumSerializationStrategy.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/UnknownEnumSerializationStrategy.java
@@ -1,0 +1,17 @@
+package com.hubspot.jackson.datatype.protobuf;
+
+import com.google.protobuf.Descriptors.EnumValueDescriptor;
+
+@FunctionalInterface
+public interface UnknownEnumSerializationStrategy {
+
+  EnumValueDescriptor handleUnknownEnumValue(EnumValueDescriptor descriptor);
+
+  UnknownEnumSerializationStrategy SERIALIZE = descriptor -> descriptor;
+
+  UnknownEnumSerializationStrategy FAIL =
+      descriptor -> {
+        throw new IllegalArgumentException(
+            "Unable to serialize an unknown enum value " + descriptor.getFullName());
+      };
+}

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/DurationSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/DurationSerializer.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -10,8 +11,8 @@ import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 
 public class DurationSerializer extends ProtobufSerializer<Duration> {
 
-  public DurationSerializer() {
-    super(Duration.class);
+  public DurationSerializer(ProtobufJacksonConfig config) {
+    super(Duration.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/FieldMaskSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/FieldMaskSerializer.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -10,8 +11,8 @@ import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 
 public class FieldMaskSerializer extends ProtobufSerializer<FieldMask> {
 
-  public FieldMaskSerializer() {
-    super(FieldMask.class);
+  public FieldMaskSerializer(ProtobufJacksonConfig config) {
+    super(FieldMask.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ListValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ListValueSerializer.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -12,8 +13,8 @@ import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 public class ListValueSerializer extends ProtobufSerializer<ListValue> {
   private static final FieldDescriptor VALUES_FIELD = ListValue.getDescriptor().findFieldByName("values");
 
-  public ListValueSerializer() {
-    super(ListValue.class);
+  public ListValueSerializer(ProtobufJacksonConfig config) {
+    super(ListValue.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
@@ -36,7 +36,7 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
   }
 
   public MessageSerializer(ProtobufJacksonConfig config) {
-    super(MessageOrBuilder.class);
+    super(MessageOrBuilder.class, config);
 
     this.config = config;
   }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/StructSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/StructSerializer.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -11,8 +12,8 @@ import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 public class StructSerializer extends ProtobufSerializer<Struct> {
   private static final FieldDescriptor FIELDS_FIELD = Struct.getDescriptor().findFieldByName("fields");
 
-  public StructSerializer() {
-    super(Struct.class);
+  public StructSerializer(ProtobufJacksonConfig config) {
+    super(Struct.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/TimestampSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/TimestampSerializer.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -10,8 +11,8 @@ import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 
 public class TimestampSerializer extends ProtobufSerializer<Timestamp> {
 
-  public TimestampSerializer() {
-    super(Timestamp.class);
+  public TimestampSerializer(ProtobufJacksonConfig config) {
+    super(Timestamp.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ValueSerializer.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -12,8 +13,8 @@ import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 
 public class ValueSerializer extends ProtobufSerializer<Value> {
 
-  public ValueSerializer() {
-    super(Value.class);
+  public ValueSerializer(ProtobufJacksonConfig config) {
+    super(Value.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/WrappedPrimitiveSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/WrappedPrimitiveSerializer.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -10,8 +11,8 @@ import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 
 public class WrappedPrimitiveSerializer<T extends MessageOrBuilder> extends ProtobufSerializer<T> {
 
-  public WrappedPrimitiveSerializer(Class<T> wrapperType) {
-    super(wrapperType);
+  public WrappedPrimitiveSerializer(Class<T> wrapperType, ProtobufJacksonConfig config) {
+    super(wrapperType, config);
   }
 
   @Override

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/proto3/EnumTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/proto3/EnumTest.java
@@ -1,0 +1,30 @@
+package com.hubspot.jackson.datatype.protobuf.proto3;
+
+import static com.hubspot.jackson.datatype.protobuf.UnknownEnumSerializationStrategy.FAIL;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf3.NestedProto3;
+import org.junit.Test;
+
+public class EnumTest {
+
+  @Test
+  public void itFailsToSerializeAnUnknownEnum() {
+    ProtobufJacksonConfig config = ProtobufJacksonConfig.builder()
+        .unknownEnumSerializationStrategy(FAIL)
+        .build();
+
+    ObjectMapper mapper = new ObjectMapper().registerModules(new ProtobufModule(config));
+
+    NestedProto3 message = NestedProto3.newBuilder()
+        .setEnumValue(42)
+        .build();
+
+    assertThatThrownBy(() -> mapper.writeValueAsString(message))
+        .hasMessageContaining("Unable to serialize an unknown enum value")
+        .hasRootCauseInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
Hi @jhaber! Thanks for this library, it is very useful :)

We have recently faced an issue related to serialization of unknown enum values coming from a newer version of a proto schema. The issue is the same as described in https://github.com/HubSpot/jackson-datatype-protobuf/issues/58. It would be great to have a way to configure the serializer to fail instead of producing values like `UNKNOWN_ENUM_VALUE_TestType_2`. For example, fail-fast behavior is desirable to avoid storing JSONs with such values in a database.

This PR adds a configurable `UnknownEnumSerializationStrategy` interface that handles unknown enum value descriptors. The default behavior is to serialize as-is. New additional behavior is to fail with `IllegalArgumentException`. The strategy is configurable via `ProtobufJacksonConfig`.

Could you please take a look at this PR and let me know if you think this is a reasonable suggestion?
Thanks a lot in advance!