### PR TITLE
Added support for Unwrapped Serialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ To use module on Maven-based projects, use following dependency:
 
 ### Versions
 
-There are separate versions based on which version of Jackson you are using, see the table below:
+Starting with version 0.9.12, only Jackson 2.9+ is supported. If you're using Jackson 2.9 or newer, you can use the latest version of this library in Maven Central ([link](https://search.maven.org/artifact/com.hubspot.jackson/jackson-datatype-protobuf)).
 
-| Jackson 2.7.x | Jackson 2.8.x | Jackson 2.9.x |
-| ------------- | ------------- | ------------- |
-| 0.9.11-jackson2.7 | 0.9.11-jackson2.8 | 0.9.11-jackson2.9 |
+If you're using a version of Jackson prior to 2.9, you can use the last release before support was dropped:
+
+| Jackson 2.7.x | Jackson 2.8.x |
+| ------------- | ------------- |
+| 0.9.11-jackson2.7 | 0.9.11-jackson2.8 
 
 ### Registering module
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
@@ -44,11 +44,7 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
     this(config, false);
   }
 
-  public MessageSerializer(ProtobufJacksonConfig config, boolean unwrappingSerializer) {
-    this(config, null, unwrappingSerializer);
-  }
-
-  public MessageSerializer(ProtobufJacksonConfig config, NameTransformer nameTransformer, boolean unwrappingSerializer) {
+  private MessageSerializer(ProtobufJacksonConfig config, boolean unwrappingSerializer) {
     super(MessageOrBuilder.class);
     this.config = config;
     this.unwrappingSerializer = unwrappingSerializer;
@@ -123,7 +119,7 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
 
   @Override
   public MessageSerializer unwrappingSerializer(NameTransformer nameTransformer) {
-    return new MessageSerializer(config, nameTransformer, true);
+    return new MessageSerializer(config, true);
   }
 
   private Function<FieldDescriptor, String> getPropertyNaming(Descriptor descriptor, SerializerProvider serializerProvider) {

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/builtin/UnwrappedSerializationTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/builtin/UnwrappedSerializationTest.java
@@ -1,0 +1,53 @@
+package com.hubspot.jackson.datatype.protobuf.builtin;
+
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.google.protobuf.ListValue;
+import com.google.protobuf.NullValue;
+import com.google.protobuf.Value;
+import com.hubspot.jackson.datatype.protobuf.util.BuiltInProtobufs;
+
+public class UnwrappedSerializationTest {
+    @Test
+    public void itWritesUnwrappedNullValue() throws IOException {
+        BuiltInProtobufs.HasValue message = BuiltInProtobufs.HasValue
+                .newBuilder()
+                .setValue(Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+                .build();
+        ValueBean bean = new ValueBean();
+        bean.setHasValue(message);
+        String json = camelCase().writeValueAsString(bean);
+        assertThat(json).isEqualTo("{\"value\":null}");
+    }
+
+    @Test
+    public void itWritesUnwrappedListValue() throws IOException {
+        ListValue list = ListValue.newBuilder().addValues(Value.newBuilder().setStringValue("test").build()).build();
+        BuiltInProtobufs.HasValue message = BuiltInProtobufs.HasValue
+                .newBuilder()
+                .setValue(Value.newBuilder().setListValue(list).build())
+                .build();
+        ValueBean bean = new ValueBean();
+        bean.setHasValue(message);
+        String json = camelCase().writeValueAsString(bean);
+        assertThat(json).isEqualTo("{\"value\":[\"test\"]}");
+    }
+
+    public static class ValueBean {
+        @JsonUnwrapped
+        private BuiltInProtobufs.HasValue hasValue;
+
+        public BuiltInProtobufs.HasValue getHasValue() {
+            return hasValue;
+        }
+        public void setHasValue(BuiltInProtobufs.HasValue hasValue) {
+            this.hasValue = hasValue;
+        }
+    }
+}


### PR DESCRIPTION
This change adds support for [Unwrapped Serialization ](https://github.com/HubSpot/jackson-datatype-protobuf/issues/78). JsonUnwrapped annotation essentially creates a new instance of the MessageSerializer with "unwrapped" flag set to avoid generating the start and end object tags.
I have added test cases for the same as well.