### PR TITLE
Add support for `json_name` attribute in protobuf

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/PropertyNamingCache.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/PropertyNamingCache.java
@@ -64,7 +64,7 @@ public class PropertyNamingCache {
 
     Map<FieldDescriptor, String> tempMap = new HashMap<>();
     for (FieldDescriptor field : descriptor.getFields()) {
-      tempMap.put(field, namingStrategy.translate(field.getName()));
+      tempMap.put(field, getFieldName(field, namingStrategy));
     }
 
     ImmutableMap<FieldDescriptor, String> fieldLookup = ImmutableMap.copyOf(tempMap);
@@ -83,7 +83,7 @@ public class PropertyNamingCache {
 
     Map<String, FieldDescriptor> tempMap = new HashMap<>();
     for (FieldDescriptor field : descriptor.getFields()) {
-      tempMap.put(namingStrategy.translate(field.getName()), field);
+      tempMap.put(getFieldName(field, namingStrategy), field);
     }
 
     if (config.acceptLiteralFieldnames()) {
@@ -96,5 +96,12 @@ public class PropertyNamingCache {
 
     Map<String, FieldDescriptor> fieldLookup = ImmutableMap.copyOf(tempMap);
     return fieldLookup::get;
+  }
+
+  private static String getFieldName(
+      FieldDescriptor field, PropertyNamingStrategyBase namingStrategy) {
+    return field.toProto().hasJsonName()
+        ? field.getJsonName()
+        : namingStrategy.translate(field.getName());
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper;
 import com.hubspot.jackson.datatype.protobuf.util.ProtobufCreator;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.PropertyNamingCamelCased;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.PropertyNamingJsonName;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.PropertyNamingSnakeCased;
 
 public class PropertyNamingTest {
@@ -215,6 +216,19 @@ public class PropertyNamingTest {
     PropertyNamingSnakeCased message = mapper.readValue(json, PropertyNamingSnakeCased.class);
 
     assertThat(message.getStringAttribute()).isEqualTo("test");
+  }
+
+  @Test
+  public void itRespectsCustomJsonPropertyNames() throws IOException {
+    ObjectMapper mapper = new ObjectMapper().registerModules(new ProtobufModule());
+    String json = "{\"custom-name\":\"v\",\"lowerCamel\":\"v2\",\"lower_underscore\":\"v3\",\"surprise!\":\"v4\"}";
+    PropertyNamingJsonName message = mapper.readValue(json, PropertyNamingJsonName.class);
+
+    assertThat(message.getCustomName()).isEqualTo("v");
+    assertThat(message.getLowerCamel()).isEqualTo("v2");
+    assertThat(message.getLowerUnderscore()).isEqualTo("v3");
+    assertThat(message.getDifferentName()).isEqualTo("v4");
+    assertThat(mapper.writeValueAsString(message)).isEqualTo(json);
   }
 
   private static PropertyNamingStrategy snakeCaseNamingBase() {

--- a/src/test/proto/test.proto
+++ b/src/test/proto/test.proto
@@ -54,6 +54,13 @@ message PropertyNamingCamelCased {
   optional string stringAttribute = 1;
 }
 
+message PropertyNamingJsonName {
+  optional string custom_name = 1 [json_name = "custom-name"];
+  optional string lower_camel = 2 [json_name = "lowerCamel"];
+  optional string lower_underscore = 3 [json_name = "lower_underscore"];
+  optional string different_name = 4 [json_name = "surprise!"];
+}
+
 message Nested {
   optional double double = 1;
   optional float float = 2;


### PR DESCRIPTION
This is to continue https://github.com/HubSpot/jackson-datatype-protobuf/pull/65, which seems to be stale unfortunately.
Credit to @blakesmith.
I only changed parts trying to address the comments.