### PR TITLE
Cache field name translations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <dep.jackson.version>2.11.0</dep.jackson.version>
     <dep.jackson-databind.version>2.11.0</dep.jackson-databind.version>
-    <dep.protobuf-java.version>3.8.0</dep.protobuf-java.version>
+    <dep.protobuf-java.version>3.19.3</dep.protobuf-java.version>
     <dep.plugin.duplicate-finder.version>1.4.0</dep.plugin.duplicate-finder.version>
   </properties>
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/MessageDeserializerFactory.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/MessageDeserializerFactory.java
@@ -46,9 +46,11 @@ public class MessageDeserializerFactory extends Deserializers.Base {
   private <T extends Message> ProtobufDeserializer<T, ?> getDeserializer(Class<T> messageType) {
     ProtobufDeserializer<?, ?> deserializer = deserializerCache.get(messageType);
     if (deserializer == null) {
-      ProtobufDeserializer<T, ?> newDeserializer = new MessageDeserializer<>(messageType, config);
-      ProtobufDeserializer<?, ?> previousDeserializer = deserializerCache.putIfAbsent(messageType, newDeserializer);
-      deserializer = previousDeserializer == null ? newDeserializer : previousDeserializer;
+      // use computeIfAbsent as a fallback because it allocates
+      deserializer = deserializerCache.computeIfAbsent(
+          messageType,
+          ignored -> new MessageDeserializer<>(messageType, config)
+      );
     }
 
     return (ProtobufDeserializer<T, ?>) deserializer;

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
@@ -54,6 +54,10 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
     this.deserializerCache = new ConcurrentHashMap<>();
   }
 
+  protected Descriptor getDescriptor() {
+    return defaultInstance.getDescriptorForType();
+  }
+
   protected abstract void populate(
           V builder,
           JsonParser parser,

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
@@ -3,10 +3,12 @@ package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.PropertyNamingStrategyBase;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -17,15 +19,16 @@ import com.google.protobuf.ExtensionRegistry.ExtensionInfo;
 import com.google.protobuf.GeneratedMessageV3.ExtendableMessageOrBuilder;
 import com.google.protobuf.MessageOrBuilder;
 import com.hubspot.jackson.datatype.protobuf.ExtensionRegistryWrapper;
-import com.hubspot.jackson.datatype.protobuf.PropertyNamingStrategyWrapper;
 import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import com.hubspot.jackson.datatype.protobuf.internal.PropertyNamingCache;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
   @SuppressFBWarnings(value="SE_BAD_FIELD")
   private final ProtobufJacksonConfig config;
+  private final Map<Descriptor, PropertyNamingCache> propertyNamingCache;
 
   /**
    * @deprecated use {@link #MessageSerializer(ProtobufJacksonConfig)} instead
@@ -39,6 +42,7 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
     super(MessageOrBuilder.class);
 
     this.config = config;
+    this.propertyNamingCache = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -53,30 +57,33 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
     Include include = serializerProvider.getConfig().getDefaultPropertyInclusion().getValueInclusion();
     boolean writeDefaultValues = proto3 && include != Include.NON_DEFAULT;
     boolean writeEmptyCollections = include != Include.NON_DEFAULT && include != Include.NON_EMPTY;
-    PropertyNamingStrategyBase namingStrategy =
-            new PropertyNamingStrategyWrapper(serializerProvider.getConfig().getPropertyNamingStrategy());
 
     Descriptor descriptor = message.getDescriptorForType();
-    List<FieldDescriptor> fields = new ArrayList<>(descriptor.getFields());
+    Function<FieldDescriptor, String> propertyNaming = getPropertyNaming(descriptor, serializerProvider);
+    List<FieldDescriptor> fields = descriptor.getFields();
     if (message instanceof ExtendableMessageOrBuilder<?>) {
+      fields = new ArrayList<>(fields);
+
       for (ExtensionInfo extensionInfo : config.extensionRegistry().getExtensionsByDescriptor(descriptor)) {
         fields.add(extensionInfo.descriptor);
       }
     }
 
     for (FieldDescriptor field : fields) {
+      String fieldName = propertyNaming.apply(field);
+
       if (field.isRepeated()) {
         List<?> valueList = (List<?>) message.getField(field);
 
         if (!valueList.isEmpty() || writeEmptyCollections) {
           if (field.isMapField()) {
-            generator.writeFieldName(namingStrategy.translate(field.getName()));
+            generator.writeFieldName(fieldName);
             writeMap(field, valueList, generator, serializerProvider);
           } else if (valueList.size() == 1 && writeSingleElementArraysUnwrapped(serializerProvider)) {
-            generator.writeFieldName(namingStrategy.translate(field.getName()));
+            generator.writeFieldName(fieldName);
             writeValue(field, valueList.get(0), generator, serializerProvider);
           } else {
-            generator.writeArrayFieldStart(namingStrategy.translate(field.getName()));
+            generator.writeArrayFieldStart(fieldName);
             for (Object subValue : valueList) {
               writeValue(field, subValue, generator, serializerProvider);
             }
@@ -84,10 +91,10 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
           }
         }
       } else if (message.hasField(field) || (writeDefaultValues && !supportsFieldPresence(field) && field.getContainingOneof() == null)) {
-        generator.writeFieldName(namingStrategy.translate(field.getName()));
+        generator.writeFieldName(fieldName);
         writeValue(field, message.getField(field), generator, serializerProvider);
       } else if (include == Include.ALWAYS && field.getContainingOneof() == null) {
-        generator.writeFieldName(namingStrategy.translate(field.getName()));
+        generator.writeFieldName(fieldName);
         generator.writeNull();
       }
     }
@@ -95,13 +102,22 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
     generator.writeEndObject();
   }
 
+  private Function<FieldDescriptor, String> getPropertyNaming(Descriptor descriptor, SerializerProvider serializerProvider) {
+    PropertyNamingCache cache = propertyNamingCache.get(descriptor);
+    if (cache == null) {
+      // use computeIfAbsent as a fallback since it allocates
+      cache = propertyNamingCache.computeIfAbsent(
+          descriptor,
+          ignored -> PropertyNamingCache.forDescriptor(descriptor, config)
+      );
+    }
+
+    return cache.forSerialization(serializerProvider.getConfig().getPropertyNamingStrategy());
+  }
+
   private static boolean supportsFieldPresence(FieldDescriptor field) {
     // messages still support field presence in proto3
     return field.getJavaType() == JavaType.MESSAGE;
-  }
-
-  private static boolean writeEmptyArrays(SerializerProvider config) {
-    return config.isEnabled(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS);
   }
 
   private static boolean writeSingleElementArraysUnwrapped(SerializerProvider config) {

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/PropertyNamingCache.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/PropertyNamingCache.java
@@ -1,0 +1,100 @@
+package com.hubspot.jackson.datatype.protobuf.internal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.PropertyNamingStrategyBase;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.hubspot.jackson.datatype.protobuf.PropertyNamingStrategyWrapper;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
+
+public class PropertyNamingCache {
+  private final Descriptor descriptor;
+  private final ProtobufJacksonConfig config;
+  private final Map<PropertyNamingStrategy, Function<FieldDescriptor, String>> serializationCache;
+  private final Map<PropertyNamingStrategy, Function<String, FieldDescriptor>> deserializationCache;
+
+  private PropertyNamingCache(Descriptor descriptor, ProtobufJacksonConfig config) {
+    this.descriptor = descriptor;
+    this.config = config;
+    this.serializationCache = Collections.synchronizedMap(new WeakHashMap<>());
+    this.deserializationCache = Collections.synchronizedMap(new WeakHashMap<>());
+  }
+
+  public static PropertyNamingCache forDescriptor(Descriptor descriptor, ProtobufJacksonConfig config) {
+    return new PropertyNamingCache(descriptor, config);
+  }
+
+  public Function<FieldDescriptor, String> forSerialization(PropertyNamingStrategy propertyNamingStrategy) {
+    Function<FieldDescriptor, String> cached = serializationCache.get(propertyNamingStrategy);
+    if (cached != null) {
+      return cached;
+    } else {
+      Function<FieldDescriptor, String> function = buildSerializationFunction(descriptor, propertyNamingStrategy);
+      serializationCache.put(propertyNamingStrategy, function);
+
+      return function;
+    }
+  }
+
+  public Function<String, FieldDescriptor> forDeserialization(PropertyNamingStrategy propertyNamingStrategy) {
+    Function<String, FieldDescriptor> cached = deserializationCache.get(propertyNamingStrategy);
+    if (cached != null) {
+      return cached;
+    } else {
+      Function<String, FieldDescriptor> function = buildDeserializationFunction(descriptor, propertyNamingStrategy);
+      deserializationCache.put(propertyNamingStrategy, function);
+
+      return function;
+    }
+  }
+
+  private Function<FieldDescriptor, String> buildSerializationFunction(
+      Descriptor descriptor,
+      PropertyNamingStrategy originalNamingStrategy
+  ) {
+    PropertyNamingStrategyBase namingStrategy =
+        new PropertyNamingStrategyWrapper(originalNamingStrategy);
+
+    Map<FieldDescriptor, String> tempMap = new HashMap<>();
+    for (FieldDescriptor field : descriptor.getFields()) {
+      tempMap.put(field, namingStrategy.translate(field.getName()));
+    }
+
+    ImmutableMap<FieldDescriptor, String> fieldLookup = ImmutableMap.copyOf(tempMap);
+    return field -> {
+      String name = fieldLookup.get(field);
+      return name == null ? namingStrategy.translate(field.getName()) : name;
+    };
+  }
+
+  private Function<String, FieldDescriptor> buildDeserializationFunction(
+      Descriptor descriptor,
+      PropertyNamingStrategy originalNamingStrategy
+  ) {
+    PropertyNamingStrategyBase namingStrategy =
+        new PropertyNamingStrategyWrapper(originalNamingStrategy);
+
+    Map<String, FieldDescriptor> tempMap = new HashMap<>();
+    for (FieldDescriptor field : descriptor.getFields()) {
+      tempMap.put(namingStrategy.translate(field.getName()), field);
+    }
+
+    if (config.acceptLiteralFieldnames()) {
+      for (FieldDescriptor field : descriptor.getFields()) {
+        if (!tempMap.containsKey(field.getName())) {
+          tempMap.put(field.getName(), field);
+        }
+      }
+    }
+
+    Map<String, FieldDescriptor> fieldLookup = ImmutableMap.copyOf(tempMap);
+    return fieldLookup::get;
+  }
+}


### PR DESCRIPTION
Currently we recompute the field name translations on every serialization/deserialization. This PR updates the message serializer/deserializer to cache these translated field names so that we don't need to recompute them each time. However, the naming strategy can change between invocations, so the cache key is effectively `[descriptor, namingStrategy]`. And in the event someone has a very high cardinality of disposable naming strategies, we use a weak hash map to avoid holding references to the naming strategy and potentially leaking memory.

Benchmark summary:

Serialization throughput +18%
Serialization latency -9%
Serialization allocations -8%

Deserialization throughput +15%
Deserialization latency -16%
Deserialization allocations -25%

Full benchmark results: https://gist.github.com/jhaber/e372ec24b99460c499b7e8fde80596df
Benchmark code: 194369402df83f3d7cb99d7443e9e038c76bd815