### PR TITLE
Update protobuf dependency to 3.22.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <dep.jackson.version>2.13.1</dep.jackson.version>
     <dep.jackson-databind.version>2.13.1</dep.jackson-databind.version>
-    <dep.protobuf-java.version>3.19.3</dep.protobuf-java.version>
+    <dep.protobuf-java.version>3.22.3</dep.protobuf-java.version>
     <dep.plugin.duplicate-finder.version>1.4.0</dep.plugin.duplicate-finder.version>
   </properties>
 


### PR DESCRIPTION
Protobuf 3.22 made some changes such that projects that compile with protobuf 3.22 have a compiled version of `Struct.Builder` that is missing a method. The exact error message is the following:

```
java.lang.NoSuchMethodError: 'com.google.protobuf.Struct$Builder com.google.protobuf.Struct$Builder.addRepeatedField(com.google.protobuf.Descriptors$FieldDescriptor, java.lang.Object)'

	at com.hubspot.jackson.datatype.protobuf.builtin.deserializers.StructDeserializer.populate(StructDeserializer.java:28)
```

This change bumps protobuf version to 3.22.3, which causes the reference to `addRepeatedField` to be correct.

There is more details in https://github.com/HubSpot/jackson-datatype-protobuf/issues/99.