### PR TITLE
Fix unsigned, write longs as strings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,6 @@
 
   <properties>
     <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
-    <basepom.test.reuse-vm>false</basepom.test.reuse-vm>
-    <basepom.test.fork-count>1</basepom.test.fork-count>
 
     <dep.jackson.version>2.13.1</dep.jackson.version>
     <dep.jackson-databind.version>2.13.1</dep.jackson-databind.version>

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
@@ -22,6 +22,7 @@ import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.Message;
 import com.google.protobuf.NullValue;
 import com.hubspot.jackson.datatype.protobuf.builtin.deserializers.MessageDeserializer;
+import com.hubspot.jackson.datatype.protobuf.internal.Constants;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -35,9 +36,6 @@ import java.util.stream.Collectors;
 public abstract class ProtobufDeserializer<T extends Message, V extends Message.Builder> extends StdDeserializer<V> {
   private static final String NULL_VALUE_FULL_NAME = NullValue.getDescriptor().getFullName();
   private static final EnumValueDescriptor NULL_VALUE_DESCRIPTOR = NullValue.NULL_VALUE.getValueDescriptor();
-  private static final BigInteger MIN_UINT64 = BigInteger.valueOf(Long.MIN_VALUE);
-  private static final BigInteger MAX_UINT64 = new BigInteger("FFFFFFFFFFFFFFFF", 16);
-
 
   private final T defaultInstance;
   @SuppressFBWarnings(value="SE_BAD_FIELD")
@@ -342,7 +340,7 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
   private int parseInt(FieldDescriptor field, JsonParser parser, DeserializationContext context) throws IOException {
     if (isUnsigned(field.getType())) {
       long longValue = _parseLongPrimitive(parser, context);
-      if (longValue < Integer.MIN_VALUE || longValue > 0xFFFFFFFFL) {
+      if (longValue < Constants.MIN_UINT32 || longValue > Constants.MAX_UINT32) {
         throw new InputCoercionException(
           parser,
           "Value " + longValue + " is out of range for " + field.getType(),
@@ -360,7 +358,7 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
   private long parseLong(FieldDescriptor field, JsonParser parser, DeserializationContext context) throws IOException {
     if (isUnsigned(field.getType())) {
       BigInteger bigIntegerValue = BigIntegerDeserializer.instance.deserialize(parser, context);
-      if (bigIntegerValue.compareTo(MIN_UINT64) < 0 || bigIntegerValue.compareTo(MAX_UINT64) > 0) {
+      if (bigIntegerValue.compareTo(Constants.MIN_UINT64) < 0 || bigIntegerValue.compareTo(Constants.MAX_UINT64) > 0) {
         throw new InputCoercionException(
             parser,
             "Value " + bigIntegerValue + " is out of range for " + field.getType(),

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
@@ -1,41 +1,43 @@
 package com.hubspot.jackson.datatype.protobuf;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
-import javax.annotation.Nonnull;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.exc.InputCoercionException;
 import com.fasterxml.jackson.core.io.NumberInput;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.NumberDeserializers.BigIntegerDeserializer;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumDescriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.Message;
 import com.google.protobuf.NullValue;
 import com.hubspot.jackson.datatype.protobuf.builtin.deserializers.MessageDeserializer;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public abstract class ProtobufDeserializer<T extends Message, V extends Message.Builder> extends StdDeserializer<V> {
   private static final String NULL_VALUE_FULL_NAME = NullValue.getDescriptor().getFullName();
   private static final EnumValueDescriptor NULL_VALUE_DESCRIPTOR = NullValue.NULL_VALUE.getValueDescriptor();
+  private static final BigInteger MIN_UINT64 = BigInteger.valueOf(Long.MIN_VALUE);
+  private static final BigInteger MAX_UINT64 = new BigInteger("FFFFFFFFFFFFFFFF", 16);
+
 
   private final T defaultInstance;
   @SuppressFBWarnings(value="SE_BAD_FIELD")
@@ -245,9 +247,9 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
 
     switch (field.getJavaType()) {
       case INT:
-        return _parseIntPrimitive(parser, context);
+        return parseInt(field, parser, context);
       case LONG:
-        return _parseLongPrimitive(parser, context);
+        return parseLong(field, parser, context);
       case FLOAT:
         return _parseFloatPrimitive(parser, context);
       case DOUBLE:
@@ -337,6 +339,42 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
     }
   }
 
+  private int parseInt(FieldDescriptor field, JsonParser parser, DeserializationContext context) throws IOException {
+    if (isUnsigned(field.getType())) {
+      long longValue = _parseLongPrimitive(parser, context);
+      if (longValue < Integer.MIN_VALUE || longValue > 0xFFFFFFFFL) {
+        throw new InputCoercionException(
+          parser,
+          "Value " + longValue + " is out of range for " + field.getType(),
+          parser.getCurrentToken(),
+          Integer.TYPE
+        );
+      } else {
+        return (int) longValue;
+      }
+    } else {
+      return _parseIntPrimitive(parser, context);
+    }
+  }
+
+  private long parseLong(FieldDescriptor field, JsonParser parser, DeserializationContext context) throws IOException {
+    if (isUnsigned(field.getType())) {
+      BigInteger bigIntegerValue = BigIntegerDeserializer.instance.deserialize(parser, context);
+      if (bigIntegerValue.compareTo(MIN_UINT64) < 0 || bigIntegerValue.compareTo(MAX_UINT64) > 0) {
+        throw new InputCoercionException(
+            parser,
+            "Value " + bigIntegerValue + " is out of range for " + field.getType(),
+            parser.getCurrentToken(),
+            Long.TYPE
+        );
+      } else {
+        return bigIntegerValue.longValue();
+      }
+    } else {
+      return _parseLongPrimitive(parser, context);
+    }
+  }
+
   private JsonDeserializer<Object> getMessageDeserializer(
           Message.Builder builder,
           FieldDescriptor field,
@@ -388,6 +426,10 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
     throw new AssertionError();
   }
 
+  private static boolean isUnsigned(Type type) {
+    return type == Type.FIXED32 || type == Type.UINT32 || type == Type.FIXED64 || type == Type.UINT64;
+  }
+
   private static boolean isDefaultMessageDeserializer(JsonDeserializer<?> deserializer) {
     final Class<?> deserializerType;
     if (deserializer instanceof BuildingDeserializer) {
@@ -415,19 +457,13 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
   }
 
   private static String indexRange(EnumDescriptor field) {
-    List<Integer> indices = Lists.transform(field.getValues(), new Function<EnumValueDescriptor, Integer>() {
-      @Override
-      public Integer apply(@Nonnull EnumValueDescriptor value) {
-        return value.getIndex();
-      }
-    });
-
-    // Guava returns non-modifiable list
-    indices = Lists.newArrayList(indices);
-
-    Collections.sort(indices);
-
-    return "[" + Joiner.on(',').join(indices) + "]";
+    return field
+      .getValues()
+      .stream()
+      .map(EnumValueDescriptor::getIndex)
+      .sorted()
+      .map(String::valueOf)
+      .collect(Collectors.joining(",", "[", "]"));
   }
 
   private static String wrongTokenMessage(FieldDescriptor field, DeserializationContext context) {

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
@@ -7,10 +7,16 @@ public class ProtobufJacksonConfig {
 
   private final ExtensionRegistryWrapper extensionRegistry;
   private final boolean acceptLiteralFieldnames;
+  private final boolean properUnsignedNumberSerialization;
 
-  private ProtobufJacksonConfig(ExtensionRegistryWrapper extensionRegistry, boolean acceptLiteralFieldnames) {
+  private ProtobufJacksonConfig(
+    ExtensionRegistryWrapper extensionRegistry,
+    boolean acceptLiteralFieldnames,
+    boolean properUnsignedNumberSerialization
+  ) {
     this.extensionRegistry = extensionRegistry;
     this.acceptLiteralFieldnames = acceptLiteralFieldnames;
+    this.properUnsignedNumberSerialization = properUnsignedNumberSerialization;
   }
 
   public static ProtobufJacksonConfig getDefaultInstance() {
@@ -29,9 +35,14 @@ public class ProtobufJacksonConfig {
     return acceptLiteralFieldnames;
   }
 
+  public boolean properUnsignedNumberSerialization() {
+    return properUnsignedNumberSerialization;
+  }
+
   public static class Builder {
     private ExtensionRegistryWrapper extensionRegistry = ExtensionRegistryWrapper.empty();
     private boolean acceptLiteralFieldnames = false;
+    private boolean properUnsignedNumberSerialization = false;
 
     private Builder() {}
 
@@ -49,8 +60,17 @@ public class ProtobufJacksonConfig {
       return this;
     }
 
+    public Builder properUnsignedNumberSerialization(boolean properUnsignedNumberSerialization) {
+      this.properUnsignedNumberSerialization = properUnsignedNumberSerialization;
+      return this;
+    }
+
     public ProtobufJacksonConfig build() {
-      return new ProtobufJacksonConfig(extensionRegistry, acceptLiteralFieldnames);
+      return new ProtobufJacksonConfig(
+        extensionRegistry,
+        acceptLiteralFieldnames,
+        properUnsignedNumberSerialization
+      );
     }
   }
 }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
@@ -8,15 +8,18 @@ public class ProtobufJacksonConfig {
   private final ExtensionRegistryWrapper extensionRegistry;
   private final boolean acceptLiteralFieldnames;
   private final boolean properUnsignedNumberSerialization;
+  private final boolean serializeLongsAsString;
 
   private ProtobufJacksonConfig(
     ExtensionRegistryWrapper extensionRegistry,
     boolean acceptLiteralFieldnames,
-    boolean properUnsignedNumberSerialization
+    boolean properUnsignedNumberSerialization,
+    boolean serializeLongsAsString
   ) {
     this.extensionRegistry = extensionRegistry;
     this.acceptLiteralFieldnames = acceptLiteralFieldnames;
     this.properUnsignedNumberSerialization = properUnsignedNumberSerialization;
+    this.serializeLongsAsString = serializeLongsAsString;
   }
 
   public static ProtobufJacksonConfig getDefaultInstance() {
@@ -39,10 +42,15 @@ public class ProtobufJacksonConfig {
     return properUnsignedNumberSerialization;
   }
 
+  public boolean serializeLongsAsString() {
+    return serializeLongsAsString;
+  }
+
   public static class Builder {
     private ExtensionRegistryWrapper extensionRegistry = ExtensionRegistryWrapper.empty();
     private boolean acceptLiteralFieldnames = false;
     private boolean properUnsignedNumberSerialization = false;
+    private boolean serializeLongsAsString = false;
 
     private Builder() {}
 
@@ -60,8 +68,19 @@ public class ProtobufJacksonConfig {
       return this;
     }
 
+    public Builder useCanonicalSerialization() {
+      properUnsignedNumberSerialization(true);
+      serializeLongsAsString(true);
+      return this;
+    }
+
     public Builder properUnsignedNumberSerialization(boolean properUnsignedNumberSerialization) {
       this.properUnsignedNumberSerialization = properUnsignedNumberSerialization;
+      return this;
+    }
+
+    public Builder serializeLongsAsString(boolean serializeLongsAsString) {
+      this.serializeLongsAsString = serializeLongsAsString;
       return this;
     }
 
@@ -69,7 +88,8 @@ public class ProtobufJacksonConfig {
       return new ProtobufJacksonConfig(
         extensionRegistry,
         acceptLiteralFieldnames,
-        properUnsignedNumberSerialization
+        properUnsignedNumberSerialization,
+        serializeLongsAsString
       );
     }
   }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
@@ -3,12 +3,18 @@ package com.hubspot.jackson.datatype.protobuf;
 import com.google.protobuf.ExtensionRegistry;
 
 public class ProtobufJacksonConfig {
+  private static final ProtobufJacksonConfig DEFAULT_INSTANCE = ProtobufJacksonConfig.builder().build();
+
   private final ExtensionRegistryWrapper extensionRegistry;
   private final boolean acceptLiteralFieldnames;
 
   private ProtobufJacksonConfig(ExtensionRegistryWrapper extensionRegistry, boolean acceptLiteralFieldnames) {
     this.extensionRegistry = extensionRegistry;
     this.acceptLiteralFieldnames = acceptLiteralFieldnames;
+  }
+
+  public static ProtobufJacksonConfig getDefaultInstance() {
+    return DEFAULT_INSTANCE;
   }
 
   public static Builder builder() {

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
@@ -63,14 +63,15 @@ public class ProtobufJacksonConfig {
       return this;
     }
 
-    public Builder acceptLiteralFieldnames(boolean acceptLiteralFieldnames) {
-      this.acceptLiteralFieldnames = acceptLiteralFieldnames;
+    public Builder useCanonicalSerialization() {
+      acceptLiteralFieldnames(true);
+      properUnsignedNumberSerialization(true);
+      serializeLongsAsString(true);
       return this;
     }
 
-    public Builder useCanonicalSerialization() {
-      properUnsignedNumberSerialization(true);
-      serializeLongsAsString(true);
+    public Builder acceptLiteralFieldnames(boolean acceptLiteralFieldnames) {
+      this.acceptLiteralFieldnames = acceptLiteralFieldnames;
       return this;
     }
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufModule.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufModule.java
@@ -53,7 +53,7 @@ public class ProtobufModule extends Module {
   private final ProtobufJacksonConfig config;
 
   public ProtobufModule() {
-    this(ProtobufJacksonConfig.builder().build());
+    this(ProtobufJacksonConfig.getDefaultInstance());
   }
 
   /**
@@ -82,22 +82,22 @@ public class ProtobufModule extends Module {
   public void setupModule(SetupContext context) {
     SimpleSerializers serializers = new SimpleSerializers();
     serializers.addSerializer(new MessageSerializer(config));
-    serializers.addSerializer(new DurationSerializer());
-    serializers.addSerializer(new FieldMaskSerializer());
-    serializers.addSerializer(new ListValueSerializer());
-    serializers.addSerializer(new NullValueSerializer());
-    serializers.addSerializer(new StructSerializer());
-    serializers.addSerializer(new TimestampSerializer());
-    serializers.addSerializer(new ValueSerializer());
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(DoubleValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(FloatValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int64Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt64Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int32Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt32Value.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BoolValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(StringValue.class));
-    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BytesValue.class));
+    serializers.addSerializer(new DurationSerializer(config));
+    serializers.addSerializer(new FieldMaskSerializer(config));
+    serializers.addSerializer(new ListValueSerializer(config));
+    serializers.addSerializer(new NullValueSerializer(config));
+    serializers.addSerializer(new StructSerializer(config));
+    serializers.addSerializer(new TimestampSerializer(config));
+    serializers.addSerializer(new ValueSerializer(config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(DoubleValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(FloatValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int64Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt64Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(Int32Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(UInt32Value.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BoolValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(StringValue.class, config));
+    serializers.addSerializer(new WrappedPrimitiveSerializer<>(BytesValue.class, config));
 
     context.addSerializers(serializers);
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
@@ -2,11 +2,6 @@ package com.hubspot.jackson.datatype.protobuf;
 
 import static java.lang.String.format;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -20,15 +15,26 @@ import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.NullValue;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class ProtobufSerializer<T extends MessageOrBuilder> extends StdSerializer<T> {
   private static final String NULL_VALUE_FULL_NAME = NullValue.getDescriptor().getFullName();
 
+  private final ProtobufJacksonConfig config;
   private final Map<Class<?>, JsonSerializer<Object>> serializerCache;
 
+  @Deprecated
   public ProtobufSerializer(Class<T> protobufType) {
+    this(protobufType, ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public ProtobufSerializer(Class<T> protobufType, ProtobufJacksonConfig config) {
     super(protobufType);
 
+    this.config = config;
     this.serializerCache = new ConcurrentHashMap<>();
   }
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
@@ -16,6 +16,7 @@ import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.NullValue;
+import com.hubspot.jackson.datatype.protobuf.internal.Constants;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
@@ -123,7 +124,7 @@ public abstract class ProtobufSerializer<T extends MessageOrBuilder> extends Std
       config.properUnsignedNumberSerialization() &&
       isUnsigned(field.getType())
     ) {
-      long unsignedValue = value & 0xFFFFFFFFL;
+      long unsignedValue = value & Constants.MAX_UINT32;
       generator.writeNumber(unsignedValue);
     } else {
       generator.writeNumber(value);

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
@@ -12,10 +12,12 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.NullValue;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -67,19 +69,19 @@ public abstract class ProtobufSerializer<T extends MessageOrBuilder> extends Std
   ) throws IOException {
     switch (field.getJavaType()) {
       case INT:
-        generator.writeNumber((Integer) value);
+        writeInt(field, (int) value, generator);
         break;
       case LONG:
-        generator.writeNumber((Long) value);
+        writeLong(field, (long) value, generator);
         break;
       case FLOAT:
-        generator.writeNumber((Float) value);
+        generator.writeNumber((float) value);
         break;
       case DOUBLE:
-        generator.writeNumber((Double) value);
+        generator.writeNumber((double) value);
         break;
       case BOOLEAN:
-        generator.writeBoolean((Boolean) value);
+        generator.writeBoolean((boolean) value);
         break;
       case STRING:
         generator.writeString((String) value);
@@ -113,6 +115,36 @@ public abstract class ProtobufSerializer<T extends MessageOrBuilder> extends Std
       default:
         throw unrecognizedType(field, generator);
     }
+  }
+
+  private void writeInt(FieldDescriptor field, int value, JsonGenerator generator) throws IOException {
+    if (
+      value < 0 &&
+      config.properUnsignedNumberSerialization() &&
+      isUnsigned(field.getType())
+    ) {
+      long unsignedValue = value & 0xFFFFFFFFL;
+      generator.writeNumber(unsignedValue);
+    } else {
+      generator.writeNumber(value);
+    }
+  }
+
+  private void writeLong(FieldDescriptor field, long value, JsonGenerator generator) throws IOException {
+    if (
+      value < 0 &&
+      config.properUnsignedNumberSerialization() &&
+      isUnsigned(field.getType())
+    ) {
+      BigInteger unsignedValue = BigInteger.valueOf(value & Long.MAX_VALUE).setBit(Long.SIZE - 1);
+      generator.writeNumber(unsignedValue);
+    } else {
+      generator.writeNumber(value);
+    }
+  }
+
+  private static boolean isUnsigned(Type type) {
+    return type == Type.FIXED32 || type == Type.UINT32 || type == Type.FIXED64 || type == Type.UINT64;
   }
 
   private static boolean writeEnumsUsingIndex(SerializerProvider config) {

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
@@ -29,6 +29,9 @@ public abstract class ProtobufSerializer<T extends MessageOrBuilder> extends Std
   private final ProtobufJacksonConfig config;
   private final Map<Class<?>, JsonSerializer<Object>> serializerCache;
 
+  /**
+   * @deprecated use {@link #ProtobufSerializer(Class, ProtobufJacksonConfig)}
+   */
   @Deprecated
   public ProtobufSerializer(Class<T> protobufType) {
     this(protobufType, ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufSerializer.java
@@ -137,7 +137,13 @@ public abstract class ProtobufSerializer<T extends MessageOrBuilder> extends Std
       isUnsigned(field.getType())
     ) {
       BigInteger unsignedValue = BigInteger.valueOf(value & Long.MAX_VALUE).setBit(Long.SIZE - 1);
-      generator.writeNumber(unsignedValue);
+      if (config.serializeLongsAsString()) {
+        generator.writeString(unsignedValue.toString());
+      } else {
+        generator.writeNumber(unsignedValue);
+      }
+    } else if (config.serializeLongsAsString()) {
+      generator.writeString(Long.toString(value));
     } else {
       generator.writeNumber(value);
     }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/DurationSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/DurationSerializer.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 
 public class DurationSerializer extends ProtobufSerializer<Duration> {
 
+  /**
+   * @deprecated use {@link #DurationSerializer(ProtobufJacksonConfig)}
+   */
   @Deprecated
   public DurationSerializer() {
     this(ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/DurationSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/DurationSerializer.java
@@ -1,17 +1,22 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import java.io.IOException;
 
 public class DurationSerializer extends ProtobufSerializer<Duration> {
 
+  @Deprecated
   public DurationSerializer() {
-    super(Duration.class);
+    this(ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public DurationSerializer(ProtobufJacksonConfig config) {
+    super(Duration.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/FieldMaskSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/FieldMaskSerializer.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 
 public class FieldMaskSerializer extends ProtobufSerializer<FieldMask> {
 
+  /**
+   * @deprecated use {@link #FieldMaskSerializer(ProtobufJacksonConfig)}
+   */
   @Deprecated
   public FieldMaskSerializer() {
     this(ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/FieldMaskSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/FieldMaskSerializer.java
@@ -1,17 +1,22 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.util.FieldMaskUtil;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import java.io.IOException;
 
 public class FieldMaskSerializer extends ProtobufSerializer<FieldMask> {
 
+  @Deprecated
   public FieldMaskSerializer() {
-    super(FieldMask.class);
+    this(ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public FieldMaskSerializer(ProtobufJacksonConfig config) {
+    super(FieldMask.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ListValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ListValueSerializer.java
@@ -12,6 +12,9 @@ import java.io.IOException;
 public class ListValueSerializer extends ProtobufSerializer<ListValue> {
   private static final FieldDescriptor VALUES_FIELD = ListValue.getDescriptor().findFieldByName("values");
 
+  /**
+   * @deprecated use {@link #ListValueSerializer(ProtobufJacksonConfig)}
+   */
   @Deprecated
   public ListValueSerializer() {
     this(ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ListValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ListValueSerializer.java
@@ -1,19 +1,24 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Value;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import java.io.IOException;
 
 public class ListValueSerializer extends ProtobufSerializer<ListValue> {
   private static final FieldDescriptor VALUES_FIELD = ListValue.getDescriptor().findFieldByName("values");
 
+  @Deprecated
   public ListValueSerializer() {
-    super(ListValue.class);
+    this(ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public ListValueSerializer(ProtobufJacksonConfig config) {
+    super(ListValue.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
@@ -1,12 +1,5 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -23,8 +16,13 @@ import com.hubspot.jackson.datatype.protobuf.ExtensionRegistryWrapper;
 import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
 import com.hubspot.jackson.datatype.protobuf.internal.PropertyNamingCache;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
   @SuppressFBWarnings(value="SE_BAD_FIELD")
@@ -45,7 +43,7 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
   }
 
   private MessageSerializer(ProtobufJacksonConfig config, boolean unwrappingSerializer) {
-    super(MessageOrBuilder.class);
+    super(MessageOrBuilder.class, config);
     this.config = config;
     this.unwrappingSerializer = unwrappingSerializer;
     this.propertyNamingCache = new ConcurrentHashMap<>();

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/NullValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/NullValueSerializer.java
@@ -1,15 +1,20 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.google.protobuf.NullValue;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
+import java.io.IOException;
 
 public class NullValueSerializer extends StdSerializer<NullValue> {
 
+  @Deprecated
   public NullValueSerializer() {
+    this(ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public NullValueSerializer(ProtobufJacksonConfig config) {
     super(NullValue.class);
   }
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/NullValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/NullValueSerializer.java
@@ -9,6 +9,9 @@ import java.io.IOException;
 
 public class NullValueSerializer extends StdSerializer<NullValue> {
 
+  /**
+   * @deprecated use {@link #NullValueSerializer(ProtobufJacksonConfig)}
+   */
   @Deprecated
   public NullValueSerializer() {
     this(ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/StructSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/StructSerializer.java
@@ -11,6 +11,9 @@ import java.io.IOException;
 public class StructSerializer extends ProtobufSerializer<Struct> {
   private static final FieldDescriptor FIELDS_FIELD = Struct.getDescriptor().findFieldByName("fields");
 
+  /**
+   * @deprecated use {@link #StructSerializer(ProtobufJacksonConfig)}
+   */
   @Deprecated
   public StructSerializer() {
     this(ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/StructSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/StructSerializer.java
@@ -1,18 +1,23 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Struct;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import java.io.IOException;
 
 public class StructSerializer extends ProtobufSerializer<Struct> {
   private static final FieldDescriptor FIELDS_FIELD = Struct.getDescriptor().findFieldByName("fields");
 
+  @Deprecated
   public StructSerializer() {
-    super(Struct.class);
+    this(ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public StructSerializer(ProtobufJacksonConfig config) {
+    super(Struct.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/TimestampSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/TimestampSerializer.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 
 public class TimestampSerializer extends ProtobufSerializer<Timestamp> {
 
+  /**
+   * @deprecated use {@link #TimestampSerializer(ProtobufJacksonConfig)}
+   */
   @Deprecated
   public TimestampSerializer() {
     this(ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/TimestampSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/TimestampSerializer.java
@@ -1,17 +1,22 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import java.io.IOException;
 
 public class TimestampSerializer extends ProtobufSerializer<Timestamp> {
 
+  @Deprecated
   public TimestampSerializer() {
-    super(Timestamp.class);
+    this(ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public TimestampSerializer(ProtobufJacksonConfig config) {
+    super(Timestamp.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ValueSerializer.java
@@ -12,6 +12,9 @@ import java.util.Map.Entry;
 
 public class ValueSerializer extends ProtobufSerializer<Value> {
 
+  /**
+   * @deprecated use {@link #ValueSerializer(ProtobufJacksonConfig)}
+   */
   @Deprecated
   public ValueSerializer() {
     this(ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ValueSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/ValueSerializer.java
@@ -1,19 +1,24 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-import java.util.Map;
-import java.util.Map.Entry;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Value;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class ValueSerializer extends ProtobufSerializer<Value> {
 
+  @Deprecated
   public ValueSerializer() {
-    super(Value.class);
+    this(ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public ValueSerializer(ProtobufJacksonConfig config) {
+    super(Value.class, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/WrappedPrimitiveSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/WrappedPrimitiveSerializer.java
@@ -1,17 +1,22 @@
 package com.hubspot.jackson.datatype.protobuf.builtin.serializers;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.MessageOrBuilder;
+import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import com.hubspot.jackson.datatype.protobuf.ProtobufSerializer;
+import java.io.IOException;
 
 public class WrappedPrimitiveSerializer<T extends MessageOrBuilder> extends ProtobufSerializer<T> {
 
+  @Deprecated
   public WrappedPrimitiveSerializer(Class<T> wrapperType) {
-    super(wrapperType);
+    this(wrapperType, ProtobufJacksonConfig.getDefaultInstance());
+  }
+
+  public WrappedPrimitiveSerializer(Class<T> wrapperType, ProtobufJacksonConfig config) {
+    super(wrapperType, config);
   }
 
   @Override

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/WrappedPrimitiveSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/WrappedPrimitiveSerializer.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 
 public class WrappedPrimitiveSerializer<T extends MessageOrBuilder> extends ProtobufSerializer<T> {
 
+  /**
+   * @deprecated use {@link #WrappedPrimitiveSerializer(Class, ProtobufJacksonConfig)}
+   */
   @Deprecated
   public WrappedPrimitiveSerializer(Class<T> wrapperType) {
     this(wrapperType, ProtobufJacksonConfig.getDefaultInstance());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/Constants.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/Constants.java
@@ -1,0 +1,10 @@
+package com.hubspot.jackson.datatype.protobuf.internal;
+
+import java.math.BigInteger;
+
+public class Constants {
+  public static final long MIN_UINT32 = Integer.MIN_VALUE;
+  public static final long MAX_UINT32 = 0xFFFFFFFFL;
+  public static final BigInteger MIN_UINT64 = BigInteger.valueOf(Long.MIN_VALUE);
+  public static final BigInteger MAX_UINT64 = new BigInteger("FFFFFFFFFFFFFFFF", 16);
+}

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/Constants.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/Constants.java
@@ -3,8 +3,11 @@ package com.hubspot.jackson.datatype.protobuf.internal;
 import java.math.BigInteger;
 
 public class Constants {
+  // should obviously be 0, but for backwards-compatibility we need to accept negative numbers
   public static final long MIN_UINT32 = Integer.MIN_VALUE;
   public static final long MAX_UINT32 = 0xFFFFFFFFL;
+
+  // should obviously be 0, but for backwards-compatibility we need to accept negative numbers
   public static final BigInteger MIN_UINT64 = BigInteger.valueOf(Long.MIN_VALUE);
   public static final BigInteger MAX_UINT64 = new BigInteger("FFFFFFFFFFFFFFFF", 16);
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonFormatCompatibilityTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonFormatCompatibilityTest.java
@@ -1,0 +1,77 @@
+package com.hubspot.jackson.datatype.protobuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.util.JsonFormat;
+import com.hubspot.jackson.datatype.protobuf.util.ProtobufCreator;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf3.AllFieldsProto3;
+import java.io.IOException;
+import org.junit.Test;
+
+public class JsonFormatCompatibilityTest {
+  private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(
+      new ProtobufModule(ProtobufJacksonConfig.builder().useCanonicalSerialization().build())
+  );
+
+  @Test
+  public void weSerializeAndJsonFormatDeserializesProto2() throws IOException {
+    repeat(() -> {
+      AllFields original = ProtobufCreator.create(AllFields.class);
+      String json = MAPPER.writeValueAsString(original);
+
+      AllFields.Builder builder = AllFields.newBuilder();
+      JsonFormat.parser().merge(json, builder);
+
+      assertThat(builder.build()).isEqualTo(original);
+    }, 1_000);
+  }
+
+  @Test
+  public void jsonFormatSerializesAndWeDeserializeProto2() throws IOException {
+    repeat(() -> {
+      AllFields original = ProtobufCreator.create(AllFields.class);
+      String json = JsonFormat.printer().print(original);
+
+      AllFields parsed = MAPPER.readValue(json, AllFields.class);
+
+      assertThat(parsed).isEqualTo(original);
+    }, 1_000);
+  }
+
+  @Test
+  public void weSerializeAndJsonFormatDeserializesProto3() throws IOException {
+    repeat(() -> {
+      AllFieldsProto3 original = ProtobufCreator.create(AllFieldsProto3.class);
+      String json = MAPPER.writeValueAsString(original);
+
+      AllFieldsProto3.Builder builder = AllFieldsProto3.newBuilder();
+      JsonFormat.parser().merge(json, builder);
+
+      assertThat(builder.build()).isEqualTo(original);
+    }, 1_000);
+  }
+
+  @Test
+  public void jsonFormatSerializesAndWeDeserializeProto3() throws IOException {
+    repeat(() -> {
+      AllFieldsProto3 original = ProtobufCreator.create(AllFieldsProto3.class);
+      String json = JsonFormat.printer().print(original);
+
+      AllFieldsProto3 parsed = MAPPER.readValue(json, AllFieldsProto3.class);
+
+      assertThat(parsed).isEqualTo(original);
+    }, 1_000);
+  }
+
+  private interface Runnable {
+    void run() throws IOException;
+  }
+
+  private static void repeat(Runnable r, int times) throws IOException {
+    for (int i = 0; i < times; i++) {
+      r.run();
+    }
+  }
+}


### PR DESCRIPTION
Related to #76, #77, #98

This PR adds some new config options. In particular:
- `properUnsignedNumberSerialization` will properly serialize uint32, fixed32, uint64, fixed64 (currently we sometimes write these as negative numbers)
- `serializeLongsAsString` will write uint64, fixed64, sint64, sfixed64 as json string, as specified by protobuf spec
- `useCanonicalSerialization` will enable the previous two options (and potentially more flags in the future, if new discrepancies are discovered)

/cc @stevie400 @Xcelled @suruuK 