### PR TITLE
Fix flakey test

### DIFF
--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/AcceptSingleValueAsArrayTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/AcceptSingleValueAsArrayTest.java
@@ -1,5 +1,9 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -7,9 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.RepeatedFields;
 import org.junit.Test;
-
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AcceptSingleValueAsArrayTest {
 
@@ -35,9 +36,9 @@ public class AcceptSingleValueAsArrayTest {
 
   private static ObjectMapper objectMapper(boolean enabled) {
     if (enabled) {
-      return camelCase().enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+      return create().enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
     } else {
-      return camelCase().disable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+      return create().disable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/FailOnNullPrimitivesTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/FailOnNullPrimitivesTest.java
@@ -1,5 +1,9 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -7,9 +11,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
 import org.junit.Test;
-
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FailOnNullPrimitivesTest {
 
@@ -111,9 +112,9 @@ public class FailOnNullPrimitivesTest {
 
   private static ObjectMapper objectMapper(boolean enabled) {
     if (enabled) {
-      return camelCase().enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+      return create().enable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
     } else {
-      return camelCase().disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
+      return create().disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES);
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/FailOnNumbersForEnumsTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/FailOnNumbersForEnumsTest.java
@@ -1,5 +1,9 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -8,9 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
 import org.junit.Test;
-
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FailOnNumbersForEnumsTest {
 
@@ -36,9 +37,9 @@ public class FailOnNumbersForEnumsTest {
 
   private static ObjectMapper objectMapper(boolean enabled) {
     if (enabled) {
-      return camelCase().enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS);
+      return create().enable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS);
     } else {
-      return camelCase().disable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS);
+      return create().disable(DeserializationFeature.FAIL_ON_NUMBERS_FOR_ENUMS);
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/FailOnUnknownPropertiesTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/FailOnUnknownPropertiesTest.java
@@ -1,5 +1,10 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.toTree;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -9,10 +14,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.hubspot.jackson.datatype.protobuf.util.ProtobufCreator;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
 import org.junit.Test;
-
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.toTree;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FailOnUnknownPropertiesTest {
 
@@ -62,9 +63,9 @@ public class FailOnUnknownPropertiesTest {
 
   private static ObjectMapper objectMapper(boolean enabled) {
     if (enabled) {
-      return camelCase().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+      return create().enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     } else {
-      return camelCase().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+      return create().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonInclusionTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonInclusionTest.java
@@ -1,14 +1,8 @@
 package com.hubspot.jackson.datatype.protobuf;
 
 import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -21,6 +15,11 @@ import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.ExtensionRegistry.ExtensionInfo;
 import com.hubspot.jackson.datatype.protobuf.util.TestExtensionRegistry;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class JsonInclusionTest {
   private static final EnumSet<Include> EXCLUDED_VALUES = presentValues("ALWAYS", "USE_DEFAULTS", "CUSTOM");
@@ -137,7 +136,7 @@ public class JsonInclusionTest {
   }
 
   private static ObjectMapper mapper(Include inclusion) {
-    return camelCase().copy().setSerializationInclusion(inclusion);
+    return create().setSerializationInclusion(inclusion);
   }
 
   private static ObjectMapper mapper(Include inclusion, ExtensionRegistry extensionRegistry) {

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingTest.java
@@ -3,6 +3,7 @@ package com.hubspot.jackson.datatype.protobuf;
 import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
 import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.toTree;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -198,10 +199,12 @@ public class PropertyNamingTest {
     }
   }
 
-  @Test(expected = UnrecognizedPropertyException.class)
-  public void itDoesntAcceptUnderscoreNameForCamelcasePropertyByDefault() throws IOException {
+  @Test
+  public void itDoesntAcceptUnderscoreNameForCamelcasePropertyByDefault() {
     String json = "{\"string_attribute\":\"test\"}";
-    camelCase().readValue(json, PropertyNamingSnakeCased.class);
+
+    Throwable t = catchThrowable(() -> camelCase().readValue(json, PropertyNamingSnakeCased.class));
+    assertThat(t).isInstanceOf(UnrecognizedPropertyException.class);
   }
 
   /**

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/ReadUnknownEnumValuesAsNullTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/ReadUnknownEnumValuesAsNullTest.java
@@ -1,5 +1,9 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -7,9 +11,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
 import org.junit.Test;
-
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class ReadUnknownEnumValuesAsNullTest {
 
@@ -53,9 +54,9 @@ public class ReadUnknownEnumValuesAsNullTest {
 
   private static ObjectMapper objectMapper(boolean enabled) {
     if (enabled) {
-      return camelCase().enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+      return create().enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
     } else {
-      return camelCase().disable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+      return create().disable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/WriteEnumsUsingIndexTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/WriteEnumsUsingIndexTest.java
@@ -1,15 +1,15 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.writeAndReadBack;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
 import org.junit.Test;
-
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.writeAndReadBack;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class WriteEnumsUsingIndexTest {
 
@@ -47,9 +47,9 @@ public class WriteEnumsUsingIndexTest {
 
   private static ObjectMapper objectMapper(boolean enabled) {
     if (enabled) {
-      return camelCase().enable(SerializationFeature.WRITE_ENUMS_USING_INDEX);
+      return create().enable(SerializationFeature.WRITE_ENUMS_USING_INDEX);
     } else {
-      return camelCase().disable(SerializationFeature.WRITE_ENUMS_USING_INDEX);
+      return create().disable(SerializationFeature.WRITE_ENUMS_USING_INDEX);
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/WriteSingleElementArraysUnwrappedTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/WriteSingleElementArraysUnwrappedTest.java
@@ -1,13 +1,13 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.create;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.RepeatedFields;
 import org.junit.Test;
-
-import static com.hubspot.jackson.datatype.protobuf.util.ObjectMapperHelper.camelCase;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class WriteSingleElementArraysUnwrappedTest {
 
@@ -39,9 +39,9 @@ public class WriteSingleElementArraysUnwrappedTest {
 
   private static ObjectMapper objectMapper(boolean enabled) {
     if (enabled) {
-      return camelCase().enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
+      return create().enable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
     } else {
-      return camelCase().disable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
+      return create().disable(SerializationFeature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED);
     }
   }
 }

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/util/ObjectMapperHelper.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/util/ObjectMapperHelper.java
@@ -1,9 +1,5 @@
 package com.hubspot.jackson.datatype.protobuf.util;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -16,11 +12,18 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.MessageOrBuilder;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 public class ObjectMapperHelper {
   private static final ObjectMapper DEFAULT = create();
   private static final ObjectMapper OLD_UNDERSCORE = create(PropertyNamingStrategy.SNAKE_CASE);
   private static final ObjectMapper NEW_UNDERSCORE = create(newUnderscoreStrategy());
+
+  public static ObjectMapper create() {
+    return new ObjectMapper().registerModule(new ProtobufModule());
+  }
 
   public static ObjectMapper camelCase() {
     return DEFAULT;
@@ -91,10 +94,6 @@ public class ObjectMapperHelper {
 
   private static ObjectMapper create(PropertyNamingStrategy namingStrategy) {
     return create().setPropertyNamingStrategy(namingStrategy);
-  }
-
-  private static ObjectMapper create() {
-    return new ObjectMapper().registerModule(new ProtobufModule());
   }
 
   private static PropertyNamingStrategy newUnderscoreStrategy() {


### PR DESCRIPTION
Mutating a static `ObjectMapper` was causing some tests to be flakey