### PR TITLE
Revert naming change

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingStrategyWrapper.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingStrategyWrapper.java
@@ -31,9 +31,7 @@ public class PropertyNamingStrategyWrapper {
 
     @Override
     public String translate(String fieldName) {
-      return fieldName.contains("_")
-        ? CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, fieldName)
-        : fieldName;
+      return CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, fieldName);
     }
   }
 }


### PR DESCRIPTION
Reverts another change from #113/#114 that can change the behavior for camel-cased proto field names