### PR TITLE
upgrade basepom, apply prettier formatting changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.2</version>
+    <version>59.3</version>
   </parent>
 
   <groupId>com.hubspot.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.3</version>
+    <version>59.4</version>
   </parent>
 
   <groupId>com.hubspot.jackson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,9 @@
   <description>Jackson Module that adds support for reading/writing protobufs</description>
 
   <properties>
+    <project.build.targetJdk>8</project.build.targetJdk>
+    <project.build.releaseJdk>8</project.build.releaseJdk>
+
     <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>56.1</version>
+    <version>59.2-SNAPSHOT</version>
   </parent>
 
   <groupId>com.hubspot.jackson</groupId>
@@ -20,7 +20,6 @@
     <dep.jackson.version>2.16.1</dep.jackson.version>
     <dep.jackson-databind.version>2.16.1</dep.jackson-databind.version>
     <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
-    <dep.protobuf-java.version>3.19.3</dep.protobuf-java.version>
     <dep.scala.version>2.12.18</dep.scala.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>59.2-SNAPSHOT</version>
+    <version>59.2</version>
   </parent>
 
   <groupId>com.hubspot.jackson</groupId>

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ExtensionRegistryWrapper.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ExtensionRegistryWrapper.java
@@ -22,7 +22,8 @@ public class ExtensionRegistryWrapper {
   private ExtensionRegistryWrapper(final ExtensionRegistry extensionRegistry) {
     this.extensionFunction =
       new Function<Descriptor, Set<ExtensionInfo>>() {
-        private final Map<Descriptor, Set<ExtensionInfo>> extensionCache = new ConcurrentHashMap<>();
+        private final Map<Descriptor, Set<ExtensionInfo>> extensionCache =
+          new ConcurrentHashMap<>();
 
         @Override
         public Set<ExtensionInfo> apply(Descriptor descriptor) {
@@ -31,9 +32,10 @@ public class ExtensionRegistryWrapper {
             return cached;
           }
 
-          Set<ExtensionInfo> extensions = extensionRegistry.getAllImmutableExtensionsByExtendedType(
-            descriptor.getFullName()
-          );
+          Set<ExtensionInfo> extensions =
+            extensionRegistry.getAllImmutableExtensionsByExtendedType(
+              descriptor.getFullName()
+            );
           extensionCache.put(descriptor, extensions);
           return extensions;
         }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufDeserializer.java
@@ -39,7 +39,8 @@ public abstract class ProtobufDeserializer<T extends Message, V extends Message.
   private static final String NULL_VALUE_FULL_NAME = NullValue
     .getDescriptor()
     .getFullName();
-  private static final EnumValueDescriptor NULL_VALUE_DESCRIPTOR = NullValue.NULL_VALUE.getValueDescriptor();
+  private static final EnumValueDescriptor NULL_VALUE_DESCRIPTOR =
+    NullValue.NULL_VALUE.getValueDescriptor();
 
   private final T defaultInstance;
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
@@ -77,9 +77,8 @@ public class MessageDeserializer<T extends Message, V extends Builder>
     }
 
     final Descriptor descriptor = builder.getDescriptorForType();
-    final Function<String, FieldDescriptor> fieldLookup = propertyNamingCache.forDeserialization(
-      context.getConfig()
-    );
+    final Function<String, FieldDescriptor> fieldLookup =
+      propertyNamingCache.forDeserialization(context.getConfig());
     final Map<String, ExtensionInfo> extensionLookup;
     if (builder instanceof ExtendableMessageOrBuilder<?>) {
       extensionLookup = buildExtensionLookup(descriptor, context);

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/AllExtensionsTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/AllExtensionsTest.java
@@ -18,7 +18,8 @@ import org.junit.Test;
 
 public class AllExtensionsTest {
 
-  private static final ExtensionRegistry EXTENSION_REGISTRY = TestExtensionRegistry.getInstance();
+  private static final ExtensionRegistry EXTENSION_REGISTRY =
+    TestExtensionRegistry.getInstance();
 
   @Test
   public void testSingleMessageCamelCase() {

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonInclusionTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonInclusionTest.java
@@ -28,7 +28,8 @@ public class JsonInclusionTest {
     "USE_DEFAULTS",
     "CUSTOM"
   );
-  private static final ExtensionRegistry EXTENSION_REGISTRY = TestExtensionRegistry.getInstance();
+  private static final ExtensionRegistry EXTENSION_REGISTRY =
+    TestExtensionRegistry.getInstance();
 
   private static Set<String> allFields;
   private static Set<String> allExtensionFields;

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/RepeatedExtensionsTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/RepeatedExtensionsTest.java
@@ -16,7 +16,8 @@ import org.junit.Test;
 
 public class RepeatedExtensionsTest {
 
-  private static final ExtensionRegistry EXTENSION_REGISTRY = TestExtensionRegistry.getInstance();
+  private static final ExtensionRegistry EXTENSION_REGISTRY =
+    TestExtensionRegistry.getInstance();
 
   @Test
   public void testSingleMessageCamelCase() {

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/util/CompileCustomProtobufs.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/util/CompileCustomProtobufs.java
@@ -71,7 +71,8 @@ public final class CompileCustomProtobufs {
       if (extensionRegistry == null) {
         throw new java.lang.NullPointerException();
       }
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields = com.google.protobuf.UnknownFieldSet.newBuilder();
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+        com.google.protobuf.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -201,7 +202,8 @@ public final class CompileCustomProtobufs {
       ) {
         return super.equals(obj);
       }
-      com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName other = (com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName) obj;
+      com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName other =
+        (com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName) obj;
 
       if (getFieldWithNoJsonName() != other.getFieldWithNoJsonName()) return false;
       if (getFieldWithJsonName() != other.getFieldWithJsonName()) return false;
@@ -403,7 +405,8 @@ public final class CompileCustomProtobufs {
 
       @java.lang.Override
       public com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName build() {
-        com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName result = buildPartial();
+        com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName result =
+          buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
@@ -412,9 +415,10 @@ public final class CompileCustomProtobufs {
 
       @java.lang.Override
       public com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName buildPartial() {
-        com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName result = new com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName(
-          this
-        );
+        com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName result =
+          new com.hubspot.jackson.datatype.protobuf.util.CompileCustomProtobufs.MixedJsonName(
+            this
+          );
         result.fieldWithNoJsonName_ = fieldWithNoJsonName_;
         result.fieldWithJsonName_ = fieldWithJsonName_;
         onBuilt();
@@ -611,15 +615,16 @@ public final class CompileCustomProtobufs {
       return DEFAULT_INSTANCE;
     }
 
-    private static final com.google.protobuf.Parser<MixedJsonName> PARSER = new com.google.protobuf.AbstractParser<MixedJsonName>() {
-      @java.lang.Override
-      public MixedJsonName parsePartialFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry
-      ) throws com.google.protobuf.InvalidProtocolBufferException {
-        return new MixedJsonName(input, extensionRegistry);
-      }
-    };
+    private static final com.google.protobuf.Parser<MixedJsonName> PARSER =
+      new com.google.protobuf.AbstractParser<MixedJsonName>() {
+        @java.lang.Override
+        public MixedJsonName parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry
+        ) throws com.google.protobuf.InvalidProtocolBufferException {
+          return new MixedJsonName(input, extensionRegistry);
+        }
+      };
 
     public static com.google.protobuf.Parser<MixedJsonName> parser() {
       return PARSER;

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/util/ProtobufCreator.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/util/ProtobufCreator.java
@@ -57,7 +57,8 @@ public class ProtobufCreator {
     Class<T> builderType,
     ExtensionRegistry extensionRegistry
   ) {
-    Class<? extends Message> messageType = (Class<? extends Message>) builderType.getDeclaringClass();
+    Class<? extends Message> messageType =
+      (Class<? extends Message>) builderType.getDeclaringClass();
     return (T) create(messageType, extensionRegistry).toBuilder();
   }
 


### PR DESCRIPTION
This PR upgrades basepom version to 59, which includes some prettier formatting changes and dependency upgrades.

Basepom changed the target JDK from 8 to 11, but I've pinned this project at JDK 8 for now.  I will still publish a release of 0.9.15 prior to merging this in, and apply this PR to the 0.9.16-SNAPSHOT version.
