### PR TITLE
find extensions in version-agnostic manner

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.ExtensionRegistry.ExtensionInfo;
-import com.google.protobuf.GeneratedMessageV3.ExtendableMessageOrBuilder;
 import com.google.protobuf.Message;
 import com.google.protobuf.Message.Builder;
 import com.hubspot.jackson.datatype.protobuf.ExtensionRegistryWrapper;
@@ -80,7 +79,7 @@ public class MessageDeserializer<T extends Message, V extends Builder>
     final Function<String, FieldDescriptor> fieldLookup =
       propertyNamingCache.forDeserialization(context.getConfig());
     final Map<String, ExtensionInfo> extensionLookup;
-    if (builder instanceof ExtendableMessageOrBuilder<?>) {
+    if (descriptor.isExtendable()) {
       extensionLookup = buildExtensionLookup(descriptor, context);
     } else {
       extensionLookup = Collections.emptyMap();

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/serializers/MessageSerializer.java
@@ -12,7 +12,6 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor.Syntax;
 import com.google.protobuf.ExtensionRegistry.ExtensionInfo;
-import com.google.protobuf.GeneratedMessageV3.ExtendableMessageOrBuilder;
 import com.google.protobuf.Message;
 import com.google.protobuf.MessageOrBuilder;
 import com.hubspot.jackson.datatype.protobuf.ExtensionRegistryWrapper;
@@ -76,7 +75,7 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
     );
     Descriptor descriptor = message.getDescriptorForType();
     List<FieldDescriptor> fields = descriptor.getFields();
-    if (message instanceof ExtendableMessageOrBuilder<?>) {
+    if (descriptor.isExtendable()) {
       fields = new ArrayList<>(fields);
 
       for (ExtensionInfo extensionInfo : getConfig()

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
@@ -12,7 +12,6 @@ import com.google.common.base.CaseFormat;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.ExtensionRegistry.ExtensionInfo;
-import com.google.protobuf.GeneratedMessageV3.ExtendableMessageOrBuilder;
 import com.google.protobuf.Message;
 import com.hubspot.jackson.datatype.protobuf.ProtobufJacksonConfig;
 import java.lang.reflect.Method;
@@ -45,7 +44,7 @@ public class MessageSchemaGenerator implements JsonFormatVisitable {
 
     Descriptor descriptor = defaultInstance.getDescriptorForType();
     List<FieldDescriptor> fields = new ArrayList<>(descriptor.getFields());
-    if (defaultInstance instanceof ExtendableMessageOrBuilder<?>) {
+    if (descriptor.isExtendable()) {
       for (ExtensionInfo extensionInfo : config
         .extensionRegistry()
         .getExtensionsByDescriptor(descriptor)) {


### PR DESCRIPTION
I was upgrading to protobuf 4.26.0 and found that this was explicitly referring to internal methods for protobuf classes generated in v3. This would prevent an upgrade to version 4 since it can no longer find GeneratedMessageV3.

The solution is to use a version-agnostic manner of checking for extensions. I believe Descriptor.isExtendable() will work. It was added in protobuf v2.6.0 and in every subsequent version.

I did not bump this project to protobuf 4 for now, since that is not a requirement, but if you want me to give it a try, let me know and I could make a separate PR.