### PR TITLE
JsonFormat compatibility for unconventionally named properties

### DIFF
--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingStrategyWrapper.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/PropertyNamingStrategyWrapper.java
@@ -8,18 +8,19 @@ import com.google.protobuf.Message;
 @SuppressWarnings("serial")
 public class PropertyNamingStrategyWrapper {
 
-  private static final NamingBase SNAKE_TO_CAMEL = new SnakeToCamelNamingStrategy();
+  static final NamingBase SNAKE_TO_CAMEL = new SnakeToCamelNamingStrategy();
 
   private final NamingBase delegate;
 
   public PropertyNamingStrategyWrapper(
     Class<? extends Message> messageType,
-    MapperConfig<?> mapperConfig
+    MapperConfig<?> mapperConfig,
+    ProtobufJacksonConfig protobufJacksonConfig
   ) {
     if (mapperConfig.getPropertyNamingStrategy() instanceof NamingBase) {
       this.delegate = (NamingBase) mapperConfig.getPropertyNamingStrategy();
     } else {
-      this.delegate = SNAKE_TO_CAMEL;
+      this.delegate = protobufJacksonConfig.propertyNamingStrategy();
     }
   }
 

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/ProtobufJacksonConfig.java
@@ -1,6 +1,8 @@
 package com.hubspot.jackson.datatype.protobuf;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.NamingBase;
 import com.google.protobuf.ExtensionRegistry;
+import com.hubspot.jackson.datatype.protobuf.internal.PropertyNamingCache;
 
 public class ProtobufJacksonConfig {
 
@@ -8,21 +10,32 @@ public class ProtobufJacksonConfig {
     .builder()
     .build();
 
+  public static class PropertyNamingStrategies {
+
+    public static final NamingBase SNAKE_TO_CAMEL =
+      PropertyNamingStrategyWrapper.SNAKE_TO_CAMEL;
+    public static final NamingBase JSON_FORMAT =
+      PropertyNamingCache.JsonFormatPropertyNamingStrategy.INSTANCE;
+  }
+
   private final ExtensionRegistryWrapper extensionRegistry;
   private final boolean acceptLiteralFieldnames;
   private final boolean properUnsignedNumberSerialization;
   private final boolean serializeLongsAsString;
+  private final NamingBase propertyNamingStrategy;
 
   private ProtobufJacksonConfig(
     ExtensionRegistryWrapper extensionRegistry,
     boolean acceptLiteralFieldnames,
     boolean properUnsignedNumberSerialization,
-    boolean serializeLongsAsString
+    boolean serializeLongsAsString,
+    NamingBase propertyNamingStrategy
   ) {
     this.extensionRegistry = extensionRegistry;
     this.acceptLiteralFieldnames = acceptLiteralFieldnames;
     this.properUnsignedNumberSerialization = properUnsignedNumberSerialization;
     this.serializeLongsAsString = serializeLongsAsString;
+    this.propertyNamingStrategy = propertyNamingStrategy;
   }
 
   public static ProtobufJacksonConfig getDefaultInstance() {
@@ -49,12 +62,17 @@ public class ProtobufJacksonConfig {
     return serializeLongsAsString;
   }
 
+  public NamingBase propertyNamingStrategy() {
+    return propertyNamingStrategy;
+  }
+
   public static class Builder {
 
     private ExtensionRegistryWrapper extensionRegistry = ExtensionRegistryWrapper.empty();
     private boolean acceptLiteralFieldnames = false;
     private boolean properUnsignedNumberSerialization = false;
     private boolean serializeLongsAsString = false;
+    private NamingBase propertyNamingStrategy = PropertyNamingStrategies.SNAKE_TO_CAMEL;
 
     private Builder() {}
 
@@ -71,6 +89,7 @@ public class ProtobufJacksonConfig {
       acceptLiteralFieldnames(true);
       properUnsignedNumberSerialization(true);
       serializeLongsAsString(true);
+      propertyNamingStrategy(PropertyNamingStrategies.JSON_FORMAT);
       return this;
     }
 
@@ -91,12 +110,21 @@ public class ProtobufJacksonConfig {
       return this;
     }
 
+    public Builder propertyNamingStrategy(NamingBase propertyNamingStrategy) {
+      this.propertyNamingStrategy =
+        propertyNamingStrategy == null
+          ? PropertyNamingStrategies.SNAKE_TO_CAMEL
+          : propertyNamingStrategy;
+      return this;
+    }
+
     public ProtobufJacksonConfig build() {
       return new ProtobufJacksonConfig(
         extensionRegistry,
         acceptLiteralFieldnames,
         properUnsignedNumberSerialization,
-        serializeLongsAsString
+        serializeLongsAsString,
+        propertyNamingStrategy
       );
     }
   }

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/builtin/deserializers/MessageDeserializer.java
@@ -119,7 +119,8 @@ public class MessageDeserializer<T extends Message, V extends Builder>
   ) {
     PropertyNamingStrategyWrapper namingStrategy = new PropertyNamingStrategyWrapper(
       messageType,
-      context.getConfig()
+      context.getConfig(),
+      config
     );
 
     Map<String, ExtensionInfo> extensionLookup = new HashMap<>();

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/PropertyNamingCache.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/PropertyNamingCache.java
@@ -1,5 +1,6 @@
 package com.hubspot.jackson.datatype.protobuf.internal;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.google.common.collect.ImmutableMap;
@@ -21,6 +22,20 @@ public class PropertyNamingCache {
   private final ProtobufJacksonConfig config;
   private final Map<PropertyNamingStrategy, Function<FieldDescriptor, String>> serializationCache;
   private final Map<PropertyNamingStrategy, Function<String, FieldDescriptor>> deserializationCache;
+
+  public static class JsonFormatPropertyNamingStrategy
+    extends PropertyNamingStrategies.NamingBase {
+
+    public static final JsonFormatPropertyNamingStrategy INSTANCE =
+      new JsonFormatPropertyNamingStrategy();
+
+    private JsonFormatPropertyNamingStrategy() {}
+
+    @Override
+    public String translate(String fieldName) {
+      return defaultJsonName(fieldName);
+    }
+  }
 
   private PropertyNamingCache(
     Descriptor descriptor,
@@ -86,7 +101,8 @@ public class PropertyNamingCache {
   ) {
     PropertyNamingStrategyWrapper namingStrategy = new PropertyNamingStrategyWrapper(
       messageType,
-      mapperConfig
+      mapperConfig,
+      config
     );
 
     Map<FieldDescriptor, String> tempMap = new HashMap<>();
@@ -107,7 +123,8 @@ public class PropertyNamingCache {
   ) {
     PropertyNamingStrategyWrapper namingStrategy = new PropertyNamingStrategyWrapper(
       messageType,
-      mapperConfig
+      mapperConfig,
+      config
     );
 
     Map<String, FieldDescriptor> tempMap = new HashMap<>();

--- a/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonFormatCompatibilityTest.java
+++ b/src/test/java/com/hubspot/jackson/datatype/protobuf/JsonFormatCompatibilityTest.java
@@ -7,6 +7,7 @@ import com.google.protobuf.util.JsonFormat;
 import com.hubspot.jackson.datatype.protobuf.util.ProtobufCreator;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf.AllFields;
 import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf3.AllFieldsProto3;
+import com.hubspot.jackson.datatype.protobuf.util.TestProtobuf3.UnconventionalProto3;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -76,6 +77,39 @@ public class JsonFormatCompatibilityTest {
         AllFieldsProto3 parsed = MAPPER.readValue(json, AllFieldsProto3.class);
 
         assertThat(parsed).isEqualTo(original);
+      },
+      1_000
+    );
+  }
+
+  @Test
+  public void jsonFormatSerializesAndWeDeserializeUnconventionalProto3()
+    throws IOException {
+    repeat(
+      () -> {
+        UnconventionalProto3 original = ProtobufCreator.create(
+          UnconventionalProto3.class
+        );
+        String json = JsonFormat.printer().print(original);
+        UnconventionalProto3 parsed = MAPPER.readValue(json, UnconventionalProto3.class);
+        assertThat(parsed).isEqualTo(original);
+      },
+      1_000
+    );
+  }
+
+  @Test
+  public void weSerializeAndJsonFormatDeserializesUnconventionalProto3()
+    throws IOException {
+    repeat(
+      () -> {
+        UnconventionalProto3 original = ProtobufCreator.create(
+          UnconventionalProto3.class
+        );
+        String json = MAPPER.writeValueAsString(original);
+        UnconventionalProto3.Builder builder = UnconventionalProto3.newBuilder();
+        JsonFormat.parser().merge(json, builder);
+        assertThat(builder.build()).isEqualTo(original);
       },
       1_000
     );

--- a/src/test/proto/test_proto3.proto
+++ b/src/test/proto/test_proto3.proto
@@ -87,3 +87,13 @@ message JsonNameProto3 {
   string lower_underscore = 3 [json_name = "lower_underscore"];
   string different_name = 4 [json_name = "surprise!"];
 }
+
+message UnconventionalProto3 {
+  string camelCase = 1;
+  string weird_UpperCamelCase = 2;
+  string weird_lowerCamelCase = 3;
+  string weird_1lowerCamelCase = 4;
+  string weird_2UpperCamelCase = 5;
+  string weird_3_lowerCamelCase = 6;
+  string weird_4_UpperCamelCase = 7;
+}


### PR DESCRIPTION
With ProtobufJacksonConfig.useCanonicalSerialization the output produced by jackson-datatype-protobuf is not compatible with JsonFormat.

```
message UnconventionalProto3 {
  string camelCase = 1;
  string weird_UpperCamelCase = 2;
  string weird_lowerCamelCase = 3;
  string weird_1lowerCamelCase = 4;
  string weird_2UpperCamelCase = 5;
  string weird_3_lowerCamelCase = 6;
  string weird_4_UpperCamelCase = 7;
}
```

E.g., JsonFormat would have produced:
`"camelCase":"value"`
while jackson-datatype-protobuf produces:
`"camelcase":"value"`

It's suggested to use another PropertyNamingStrategy with useCanonicalSerialization.