### PR TITLE
Support protobuf 3 optional as null

### DIFF
--- a/src/main/java/com/hubspot/jackson3/datatype/protobuf/builtin/serializers/MessageSerializer.java
+++ b/src/main/java/com/hubspot/jackson3/datatype/protobuf/builtin/serializers/MessageSerializer.java
@@ -105,7 +105,7 @@ public class MessageSerializer extends ProtobufSerializer<MessageOrBuilder> {
       ) {
         generator.writeName(fieldName);
         writeValue(field, message.getField(field), generator, serializationContext);
-      } else if (include == Include.ALWAYS && field.getContainingOneof() == null) {
+      } else if (include == Include.ALWAYS && field.getRealContainingOneof() == null) {
         generator.writeName(fieldName);
         generator.writeNull();
       }


### PR DESCRIPTION
```
 if (include == Include.ALWAYS && field.getContainingOneof() == null) {
        generator.writeName(fieldName);
        generator.writeNull();
      }
```
Protobuf 3 optional fields are converted to a synthetic oneof, causing this to return false. `getRealContainingOneof` checks for this case and would include unset optional fields as  null instead of ignoring them.