### PR TITLE
Guard against null objectVisitor in MessageSchemaGenerator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
 
-    <dep.jackson.version>2.21.3</dep.jackson.version>
-    <dep.jackson-databind.version>2.21.3</dep.jackson-databind.version>
+    <dep.jackson.version>2.18.3</dep.jackson.version>
+    <dep.jackson-databind.version>2.18.3</dep.jackson-databind.version>
     <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
     <dep.protobuf-java.version>4.28.3</dep.protobuf-java.version>
     <dep.protoc.version>${dep.protobuf-java.version}</dep.protoc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>63.10</version>
+    <version>69.0</version>
   </parent>
 
   <groupId>com.hubspot.jackson</groupId>
   <artifactId>jackson-datatype-protobuf</artifactId>
-  <version>0.9.19-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Jackson Module that adds support for reading/writing protobufs</description>
@@ -22,8 +22,8 @@
     <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
 
-    <dep.jackson.version>2.18.1</dep.jackson.version>
-    <dep.jackson-databind.version>2.18.1</dep.jackson-databind.version>
+    <dep.jackson.version>2.21.3</dep.jackson.version>
+    <dep.jackson-databind.version>2.21.3</dep.jackson-databind.version>
     <dep.javax-validation.version>2.0.1.Final</dep.javax-validation.version>
     <dep.protobuf-java.version>4.28.3</dep.protobuf-java.version>
     <dep.protoc.version>${dep.protobuf-java.version}</dep.protoc.version>

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
@@ -42,8 +42,10 @@ public class MessageSchemaGenerator implements JsonFormatVisitable {
   ) throws JsonMappingException {
     JsonObjectFormatVisitor objectVisitor = visitor.expectObjectFormat(typeHint);
     if (objectVisitor == null) {
+      System.err.println("[DEBUG-PROTO] expectObjectFormat returned null for type=" + typeHint.getRawClass().getSimpleName() + " visitor=" + visitor.getClass().getName());
       return;
     }
+    System.err.println("[DEBUG-PROTO] expectObjectFormat OK for type=" + typeHint.getRawClass().getSimpleName() + " fields=" + defaultInstance.getDescriptorForType().getFields().size());
 
     Descriptor descriptor = defaultInstance.getDescriptorForType();
     List<FieldDescriptor> fields = new ArrayList<>(descriptor.getFields());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
@@ -42,20 +42,8 @@ public class MessageSchemaGenerator implements JsonFormatVisitable {
   ) throws JsonMappingException {
     JsonObjectFormatVisitor objectVisitor = visitor.expectObjectFormat(typeHint);
     if (objectVisitor == null) {
-      System.err.println(
-        "[DEBUG-PROTO] expectObjectFormat returned null for type=" +
-        typeHint.getRawClass().getSimpleName() +
-        " visitor=" +
-        visitor.getClass().getName()
-      );
       return;
     }
-    System.err.println(
-      "[DEBUG-PROTO] expectObjectFormat OK for type=" +
-      typeHint.getRawClass().getSimpleName() +
-      " fields=" +
-      defaultInstance.getDescriptorForType().getFields().size()
-    );
 
     Descriptor descriptor = defaultInstance.getDescriptorForType();
     List<FieldDescriptor> fields = new ArrayList<>(descriptor.getFields());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
@@ -42,10 +42,20 @@ public class MessageSchemaGenerator implements JsonFormatVisitable {
   ) throws JsonMappingException {
     JsonObjectFormatVisitor objectVisitor = visitor.expectObjectFormat(typeHint);
     if (objectVisitor == null) {
-      System.err.println("[DEBUG-PROTO] expectObjectFormat returned null for type=" + typeHint.getRawClass().getSimpleName() + " visitor=" + visitor.getClass().getName());
+      System.err.println(
+        "[DEBUG-PROTO] expectObjectFormat returned null for type=" +
+        typeHint.getRawClass().getSimpleName() +
+        " visitor=" +
+        visitor.getClass().getName()
+      );
       return;
     }
-    System.err.println("[DEBUG-PROTO] expectObjectFormat OK for type=" + typeHint.getRawClass().getSimpleName() + " fields=" + defaultInstance.getDescriptorForType().getFields().size());
+    System.err.println(
+      "[DEBUG-PROTO] expectObjectFormat OK for type=" +
+      typeHint.getRawClass().getSimpleName() +
+      " fields=" +
+      defaultInstance.getDescriptorForType().getFields().size()
+    );
 
     Descriptor descriptor = defaultInstance.getDescriptorForType();
     List<FieldDescriptor> fields = new ArrayList<>(descriptor.getFields());

--- a/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
+++ b/src/main/java/com/hubspot/jackson/datatype/protobuf/internal/MessageSchemaGenerator.java
@@ -41,6 +41,9 @@ public class MessageSchemaGenerator implements JsonFormatVisitable {
     JavaType typeHint
   ) throws JsonMappingException {
     JsonObjectFormatVisitor objectVisitor = visitor.expectObjectFormat(typeHint);
+    if (objectVisitor == null) {
+      return;
+    }
 
     Descriptor descriptor = defaultInstance.getDescriptorForType();
     List<FieldDescriptor> fields = new ArrayList<>(descriptor.getFields());


### PR DESCRIPTION
## Summary

  - MessageSchemaGenerator.acceptJsonFormatVisitor crashes with a NullPointerException when visitor.expectObjectFormat() returns null, because it unconditionally calls objectVisitor.optionalProperty() on the
  result
  - The previous MessageSerializer implementation (before the refactor into MessageSchemaGenerator) had a null guard: if (v2 == null) { return; } — this was lost in the extraction

##  Impact

  Schema generators (e.g. mbknor-jackson-jsonSchema / kjetland) pass visitors where expectObjectFormat can return null. Without the guard, any type that transitively references a protobuf Message fails schema
  generation with:

  Cannot invoke "JsonObjectFormatVisitor.optionalProperty(...)" because "objectVisitor" is null

  This causes two downstream problems in consumers like HubSpot's swagger schema generator:
  1. Types containing protobuf properties fall back to legacy generation, losing schema fidelity
  2. Protobuf message definitions (e.g. Metric, Property) render as opaque type: "object" with no properties instead of their full field schemas
